### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ module.exports.before = {
 
 ```javascript
 module.exports.before = {
-  all: [ hooks.removeQuery('employee.dept') ]
+  all: [ hooks.pluckQuery('employee.dept') ]
 };
 ```
 


### PR DESCRIPTION
Example of retaining only selected criteria should read `hooks.pluckQuery` rather than `hooks.removeQuery`