### PR TITLE
Added promiseToCallback, perhaps more rugged than Feathers' code

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ this count does not include the callback param itself.
 The wrapped function will always be called with that many params,
 preventing potential bugs.
 
+(4) Wrap a Promise into a function that calls a callback.
+
+- The callback does not run in the Promise's scope. The Promise's `catch` chain is not invoked if the callback throws.
+
+```javascript
+import { promiseToCallback } from 'feathers-hooks-common/promisify'
+
+function (cb) {
+  const promise = new Promise( ...).then( ... ).catch( ... );
+  ...
+  promiseToCallback(promise)(cb);
+  promise.then( ... ); // this is still possible
+}
+```
+
 ## <a name="conditionalHooks"></a> Running hooks conditionally
 
 There are times when you may want to run a hook conditionally,

--- a/test/promiseToCallback.test.js
+++ b/test/promiseToCallback.test.js
@@ -1,0 +1,69 @@
+
+/* eslint no-param-reassign: 0, no-shadow: 0, no-unused-vars: 0, no-var: 0 */
+
+const assert = require('chai').assert;
+const promiseToCallback = require('../lib/promisify').promiseToCallback;
+
+const promise1 = (ifResolve) => new Promise((resolve, reject) => {
+  return ifResolve ? resolve('ok') : reject('bad');
+});
+
+describe('promiseToCallback', () => {
+  it('calls callback on resolve', (done) => {
+    promiseToCallback(promise1(true))((err, data) => {
+      assert.strictEqual(err, null, 'err code set');
+      assert.strictEqual(data, 'ok');
+
+      done();
+    });
+  });
+
+  it('calls callback on reject', (done) => {
+    promiseToCallback(promise1(false))((err) => {
+      assert.strictEqual(err, 'bad', 'err code set');
+
+      done();
+    });
+  });
+
+  it('promise is still then\'able', (done) => {
+    const promise = promise1(true);
+    promiseToCallback(promise)(() => {});
+
+    promise.then(() => {
+      done();
+    });
+  });
+
+  /* No idea how to test this.
+     The throw from another scope gets caught by Mocha. try..catcj don't prevent it.
+  it('promise\'s catch chain not invoked if callback throws', (done) => {
+    var callbackThrows = false;
+    var catchCalled = false;
+
+    assert.doesNotThrow(() => {
+      new Promise((resolve, reject) => {
+        const promise = promise1(true);
+
+        promiseToCallback(promise)(() => {
+          callbackThrows = true;
+          throw new Error('callback throws');
+        });
+
+        resolve();
+      })
+        .catch(err => {
+          catchCalled = true;
+          throw new Error('catch throws');
+        });
+    }, 'callback throws');
+
+    setTimeout(() => {
+      assert.equal(callbackThrows, true, 'callback did not throw');
+      assert.equal(catchCalled, false, 'catch was called');
+
+      done();
+    }, 500);
+  });
+  */
+});


### PR DESCRIPTION
The callback is invoked outside the scope of the Promise.
The Promise's .catch() chain is not invoked if the callback throws.
This code is used within feathers-service-verify-reset to resolve
eddyystop/feathers-service-verify-reset#12