### PR TITLE
Fix bug in populate, sending wrong params

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -414,7 +414,7 @@ export function populate (target, options) {
         item = item.toJSON(options);
       }
       // Remove any query from params as it's not related
-      const params = Object.assign({}, params, { query: undefined });
+      const params = Object.assign({}, hook.params, { query: undefined });
       // If the relationship is an array of ids, fetch and resolve an object for each,
       // otherwise just fetch the object.
       const promise = Array.isArray(id)


### PR DESCRIPTION
### Summary

Fix bug using empty params in populate hook, causing for example a remove after hook on populated item to be ignored even if called from non-internal provider.