### PR TITLE
Fix softDelete error on 'find'

### DIFF
--- a/src/new.js
+++ b/src/new.js
@@ -21,7 +21,7 @@ export const softDelete = (field) => (hook) => {
 
   if (hook.method === 'find') {
     hook.params.query = hook.params.query || {};
-    setByDot(hook.data, `${field || 'deleted'}.$ne`, true);// include non-deleted items only
+    setByDot(hook.params.query, `${field || 'deleted'}.$ne`, true);// include non-deleted items only
     return hook;
   }
 


### PR DESCRIPTION
### Summary
Adding `softDelete()` to a before hook for find is throwing `Cannot read property 'hasOwnProperty' of undefined` which appears to be caused by trying to modify the `hook.data` param instead of `hook.params.query`