### PR TITLE
fix setUpdatedAt and setCreatedAt

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -376,7 +376,7 @@ export function disable (realm, ...args) {
  *
  * 'options.field' is the foreign key for one related item in options.service, i.e. item[options.field] === foreignItem[idField].
  * 'target' is set to this related item once it is read successfully.
- * 
+ *
  * If 'options.field' is not present in the hook result item, the hook is ignored.
  *
  * So if the hook result has the message item

--- a/src/common.js
+++ b/src/common.js
@@ -16,7 +16,9 @@ import { getItems, replaceItems, setByDot, checkContext } from './utils';
 const setField = (defaultFieldName, value, ...fieldNames) => {
   const addFields = data => {
     for (const field of fieldNames) {
-      setByDot(data, field, value);
+      const fieldValue = typeof value === 'function' ? value() : value;
+
+      setByDot(data, field, fieldValue);
     }
   };
 
@@ -69,7 +71,7 @@ const setField = (defaultFieldName, value, ...fieldNames) => {
  * }));
  *
  */
-export const setCreatedAt = (...fieldNames) => setField('createdAt', new Date(), ...fieldNames);
+export const setCreatedAt = (...fieldNames) => setField('createdAt', () => new Date(), ...fieldNames);
 
 /**
  * Set the fields to the current date-time. The fields are either in the data submitted
@@ -92,7 +94,7 @@ export const setCreatedAt = (...fieldNames) => setField('createdAt', new Date(),
  * }));
  *
  */
-export const setUpdatedAt = (...fieldNames) => setField('updatedAt', new Date(), ...fieldNames);
+export const setUpdatedAt = (...fieldNames) => setField('updatedAt', () => new Date(), ...fieldNames);
 
 /**
  * Normalize slug, so it can be accessed in the same place regardless of provider and transport.


### PR DESCRIPTION
The docs for `setCreatedAt` and setUpdatedAt` says that they "Set the fields to the current date-time" but they set the date when the feathers application bootstraps.

That's because the `new Date` function is called during the bootstrap and not every time the hook is triggered. To solve that, I've changed the `setField` method so that now it can accept a function as second argument and it will call it when the hook is actually triggered.