### PR TITLE
Added support for multiple hooks in iff()

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,12 @@ while others do not.
 
 Run a predicate function,
 which returns either a boolean, or a Promise which evaluates to a boolean.
-Run the hook if the result is truesy.
+Run one or more hooks if the result is truesy.
 
 ```javascript
 // sync predicate and hook
 const isNotAdmin = adminRole => hook => hook.params.user.roles.indexOf(adminRole || 'admin') === -1;
-hooks.iff(isNotAdmin(), hooks.remove('securityKey'))
+hooks.iff(isNotAdmin(), hooks.remove('securityKey'), hook2, ...)
 );
 // async predicate and hook
 hooks.iff(

--- a/test/doHooks.test.js
+++ b/test/doHooks.test.js
@@ -1,0 +1,131 @@
+
+const assert = require('chai').assert;
+const feathers = require('feathers');
+const memory = require('feathers-memory');
+const feathersHooks = require('feathers-hooks');
+const hooks = require('../src');
+
+const startId = 6;
+const storeInit = {
+  '0': { name: 'Jane Doe', key: 'a', id: 0 },
+  '1': { name: 'Jack Doe', key: 'a', id: 1 },
+  '2': { name: 'Jack Doe', key: 'a', id: 2, deleted: true },
+  '3': { name: 'Rick Doe', key: 'b', id: 3 },
+  '4': { name: 'Dick Doe', key: 'b', id: 4 },
+  '5': { name: 'Dick Doe', key: 'b', id: 5, deleted: true }
+};
+let store;
+
+function services () {
+  const app = this;
+  app.configure(user);
+}
+
+function user () {
+  const app = this;
+  let service;
+  let hookId;
+  let hookData;
+  let hookParamsQuery;
+  store = clone(storeInit);
+
+  app.use('/users', memory({
+    store,
+    startId
+  }));
+
+  app.service('users').before({
+    all: [
+      function (hook) {
+        if (hook.app !== app) { throw new Error('App wrong 0.'); }
+        service = this;
+
+        hook.data = { a: 'a' };
+
+        hookId = hook.id;
+        hookData = clone(hook.data);
+        hookParamsQuery = clone(hook.params.query);
+
+        return hook;
+      },
+      hooks.doHooks(
+        function (hook) {
+          if (hook.app !== app) { throw new Error('App wrong 1.'); }
+          if (service !== this) { throw new Error('Service wrong 1.'); }
+          hook.params.trace = ['sync1'];
+          return hook;
+        },
+        function (hook) {
+          if (hook.app !== app) { throw new Error('App wrong 2.'); }
+          if (service !== this) { throw new Error('Service wrong 2.'); }
+
+          if (hook.params.query.key === 'b') { throw new Error('Requested throw.'); }
+
+          hook.params.trace.push('promise1');
+          return Promise.resolve(hook);
+        },
+        function (hook) {
+          if (hook.app !== app) { throw new Error('App wrong 3.'); }
+          if (service !== this) { throw new Error('Service wrong 3.'); }
+          hook.params.trace.push('sync2');
+        },
+        function (hook, cb) {
+          if (hook.app !== app) { throw new Error('App wrong 4.'); }
+          if (service !== this) { throw new Error('Service wrong 4.'); }
+          hook.params.trace.push('cb1');
+          cb(null, hook);
+        },
+        function (hook) {
+          if (hook.app !== app) { throw new Error('App wrong 5.'); }
+          if (service !== this) { throw new Error('Service wrong 5.'); }
+          hook.params.trace.push('sync3');
+          return hook;
+        },
+      ),
+      function (hook) {
+        if (hook.app !== app) { throw new Error('App wrong 9.'); }
+        if (service !== this) { throw new Error('Service wrong 9.'); }
+
+        assert.equal(hook.id, hookId);
+        assert.deepEqual(hook.data, hookData);
+        assert.deepEqual(hook.params.query, hookParamsQuery);
+
+        assert.deepEqual(hook.params.trace, ['sync1', 'promise1', 'sync2', 'cb1', 'sync3']);
+      }
+    ]
+  });
+}
+
+describe('doHooks', () => {
+  let app;
+  let user;
+
+  beforeEach(() => {
+    app = feathers()
+      .configure(feathersHooks())
+      .configure(services);
+    user = app.service('users');
+  });
+
+  it('runs successful hooks', done => {
+    user.find({query: { key: 'a' }})
+      .then(data => {
+        done();
+      });
+  });
+
+  it('throws on unsuccessful hook', done => {
+    user.find({query: { key: 'b' }})
+      .catch(() => {
+        done();
+      })
+      .then(data => {
+        assert.fail(true, false);
+        done();
+      });
+  });
+});
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/isNot.test.js
+++ b/test/isNot.test.js
@@ -97,15 +97,12 @@ describe('isNot - works with iff and isProvider', () => {
   });
 
   it('calls sync hook function if truthy', () => {
-    const result = hooks.iff(isNot(isProvider('server')), hookFcnSync)(hook);
-
-    if (result && typeof result.then === 'function') {
-      assert.fail(true, false, 'promise unexpectedly returned');
-    } else {
-      assert.deepEqual(result, hookAfter);
-      assert.equal(hookFcnSyncCalls, 1);
-      assert.deepEqual(hook, hookAfter);
-    }
+    hooks.iff(isNot(isProvider('server')), hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
   });
 
   it('does not call sync hook function if falsey', () => {

--- a/test/isProvider.test.js
+++ b/test/isProvider.test.js
@@ -106,15 +106,12 @@ describe('isProvider - works with iff', () => {
   });
 
   it('calls sync hook function if truthy', () => {
-    const result = hooks.iff(isProvider('rest'), hookFcnSync)(hook);
-
-    if (result && typeof result.then === 'function') {
-      assert.fail(true, false, 'promise unexpectedly returned');
-    } else {
-      assert.deepEqual(result, hookAfter);
-      assert.equal(hookFcnSyncCalls, 1);
-      assert.deepEqual(hook, hookAfter);
-    }
+    hooks.iff(isProvider('rest'), hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
   });
 
   it('does not call sync hook function if falsey', () => {


### PR DESCRIPTION
- exporting doHooks which runs multi hooks using
feathers-hooks/lib/commons.processHooks
- changed iff() to call doHooks
- wrote tests for doHooks
- changed iff tests as doHooks always returns a Promise
- change isNot, isProvider tests for the same reason