### PR TITLE
adding a some hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ tmp*
 
 # The compiled/babelified modules
 lib/
+
+# Yarnfile
+yarn.lock

--- a/src/new.js
+++ b/src/new.js
@@ -183,7 +183,6 @@ export const iff = (ifFcn, ...rest) => {
 
 export const when = iff;
 
-
 /**
  * Hook that executes a set of hooks and returns true if at least one of
  * the hooks returns a truthy value and false if none of them do.
@@ -230,7 +229,6 @@ export const some = (...rest) => function (hook) {
  *   return hooks.every(hook1, hook2, ...).call(this, currentHook)
  *     .then(hook => { ... });
  * }
- */
  */
 
 export const every = (...rest) => function (hook) {

--- a/src/new.js
+++ b/src/new.js
@@ -197,18 +197,8 @@ export const iff = (ifFcn, ...rest) => {
  * }
  */
 
-export const some = (...rest) => (hook) => {
-  const hooks = rest.map(fn => {
-    let promise;
-
-    try {
-      promise = fn.call(this, hook).catch(() => Promise.resolve(false));
-    } catch (error) {
-      promise = Promise.resolve(false);
-    }
-
-    return promise;
-  });
+export const some = (...rest) => function (hook) {
+  const hooks = rest.map(fn => fn.call(this, hook));
 
   return Promise.all(hooks).then(results => {
     return Promise.resolve(results.some(result => !!result));

--- a/test/some.test.js
+++ b/test/some.test.js
@@ -1,0 +1,76 @@
+
+const assert = require('chai').assert;
+const feathers = require('feathers');
+const memory = require('feathers-memory');
+const feathersHooks = require('feathers-hooks');
+const hooks = require('../src');
+
+describe('some', () => {
+  let app;
+
+  beforeEach(() => {
+    app = feathers()
+      .configure(feathersHooks())
+      .use('/users', memory());
+  });
+
+  describe('when at least 1 hook is truthy', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.some(
+                (hook) => {
+                  throw new Error('Hook 1 errored');
+                },
+                (hook) => true,
+                (hook) => false,
+                (hook) => Promise.resolve(true),
+                (hook) => Promise.resolve(false),
+                (hook) => Promise.reject(new Error('Last Hook errored'))
+              ),
+              (hook) => Promise.resolve(hook)
+            )
+          ]
+        }
+      });
+    });
+
+    it('returns true', () => {
+      return app.service('users').find().then(result => {
+        assert.deepEqual(result, []);
+      });
+    });
+  });
+
+  describe('when at least all hooks are falsey', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.isNot(
+                hooks.some(
+                  (hook) => {
+                    throw new Error('Hook 1 errored');
+                  },
+                  (hook) => false,
+                  (hook) => Promise.resolve(false),
+                  (hook) => Promise.reject(new Error('Last Hook errored'))
+                )
+              ),
+              () => Promise.reject(new Error('Some Failed'))
+            )
+          ]
+        }
+      });
+    });
+
+    it('returns false', () => {
+      return app.service('users').find().catch(error => {
+        assert.equal(error.message, 'Some Failed');
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Adding a utility hook that takes in other functions and resolves to `true` if any of the functions return true. Resolves to `false` if all functions return falsey values. Errors thrown from a hook function are deemed as falsey and are swallowed. This is the only thing I'm not sure of. What should it do?

**EDIT**: It now rejects errors in the hook chain properly.

Usage is like so:

```js
some(hook1, hook2, hook3)
````

### Other Information

Related to this discussion https://github.com/feathersjs/feathers-permissions/issues/4

cc/ @daffl @bedeoverend 