### PR TITLE
Added new populate, dePopulate, serialze hooks.

### DIFF
--- a/src/bundled.js
+++ b/src/bundled.js
@@ -394,6 +394,11 @@ export function disable (realm, ...args) {
 export function legacyPopulate (target, options) {
   options = Object.assign({}, options);
 
+  console.error(
+    'Calling populate(target, options) is now DEPRECATED and will be removed in the future. ' +
+    'Refer to docs.feathersjs.com for more information. (legacyPopulate)'
+  );
+
   if (!options.service) {
     throw new Error('You need to provide a service. (populate)');
   }

--- a/src/bundled.js
+++ b/src/bundled.js
@@ -391,7 +391,7 @@ export function disable (realm, ...args) {
  *
  * If 'senderId' is an array of keys, then 'sender' will be an array of populated items.
  */
-export function populate (target, options) {
+export function legacyPopulate (target, options) {
   options = Object.assign({}, options);
 
   if (!options.service) {

--- a/src/dePopulate.js
+++ b/src/dePopulate.js
@@ -1,5 +1,5 @@
 
-import { getItems, replaceItems } from 'feathers-hooks-common/lib/utils';
+import { getItems, replaceItems } from './utils';
 
 export const dePopulate = () => hook => {
   const items = getItems(hook);

--- a/src/dePopulate.js
+++ b/src/dePopulate.js
@@ -1,0 +1,24 @@
+
+import { getItems, replaceItems } from 'feathers-hooks-common/lib/utils';
+
+export const dePopulate = () => hook => {
+  const items = getItems(hook);
+
+  (Array.isArray(items) ? items : [items]).forEach(item => {
+    if ('_computed' in item) {
+      item._computed.forEach(key => { delete item[key]; });
+      delete item._computed;
+    }
+
+    if ('_include' in item) {
+      item._include.forEach(key => { delete item[key]; });
+      delete item._include;
+    }
+
+    delete item._elapsed;
+  });
+
+  replaceItems(hook, items);
+  return hook;
+};
+

--- a/src/dePopulate.js
+++ b/src/dePopulate.js
@@ -5,16 +5,8 @@ export const dePopulate = () => hook => {
   const items = getItems(hook);
 
   (Array.isArray(items) ? items : [items]).forEach(item => {
-    if ('_computed' in item) {
-      item._computed.forEach(key => { delete item[key]; });
-      delete item._computed;
-    }
-
-    if ('_include' in item) {
-      item._include.forEach(key => { delete item[key]; });
-      delete item._include;
-    }
-
+    removeProps('_computed', item);
+    removeProps('_include', item);
     delete item._elapsed;
   });
 
@@ -22,3 +14,9 @@ export const dePopulate = () => hook => {
   return hook;
 };
 
+function removeProps (name, item) {
+  if (name in item) {
+    item[name].forEach(key => { delete item[key]; });
+    delete item[name];
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 export default Object.assign({},
   require('./common'),
   require('./bundled'),
-  require('./new')
+  require('./new'),
+  require('./populate'),
+  require('./dePopulate'),
+  require('./serialize')
 );

--- a/src/populate.js
+++ b/src/populate.js
@@ -1,0 +1,184 @@
+
+import errors from 'feathers-errors';
+import { getItems, replaceItems, getByDot } from './utils';
+import { legacyPopulate } from './bundled';
+
+export const populate = (options, ...rest) => {
+  if (typeof options === 'string') {
+    return legacyPopulate(options, ...rest);
+  }
+
+  return hook => {
+    const optionsDefault = {
+      schema: {},
+      checkPermissions: () => true,
+      profile: false
+    };
+
+    if (hook.params._populate === 'skip') { // this service call made from another populate
+      return hook;
+    }
+
+    return Promise.resolve()
+      .then(() => {
+        // 'options.schema' resolves to { permissions: '...', include: [ ... ] }
+
+        const items = getItems(hook);
+        const options1 = Object.assign({}, optionsDefault, options);
+        const { schema, checkPermissions } = options1;
+        const schema1 = typeof schema === 'function' ? schema(hook, options1) : schema;
+        const permissions = schema1.permissions || null;
+
+        if (typeof checkPermissions !== 'function') {
+          throw new errors.BadRequest('Permissions param is not a function. (populate)');
+        }
+
+        if (permissions && !checkPermissions(hook, hook.path, permissions, 0)) {
+          throw new errors.BadRequest('Permissions do not allow this populate. (populate)');
+        }
+
+        if (typeof schema1 !== 'object') {
+          throw new errors.BadRequest('Schema does not resolve to an object. (populate)');
+        }
+
+        return !schema1.include || !Object.keys(schema1.include).length ? items
+          : populateItemArray(options1, hook, items, schema1.include, 0);
+      })
+      .then(items => {
+        replaceItems(hook, items);
+        return hook;
+      });
+  };
+};
+
+function populateItemArray (options, hook, items, includeSchema, depth) {
+  // 'items' is an item or an array of items
+  // 'includeSchema' is like [ { nameAs: 'author', ... }, { nameAs: 'readers', ... } ]
+
+  if (!Array.isArray(items)) {
+    return populateItem(options, hook, items, includeSchema, depth + 1);
+  }
+
+  return Promise.all(
+    items.map(item => populateItem(options, hook, item, includeSchema, depth + 1))
+  );
+}
+
+function populateItem (options, hook, item, includeSchema, depth) {
+  // 'item' is one item
+  // 'includeSchema' is like [ { nameAs: 'author', ... }, { nameAs: 'readers', ... } ]
+
+  const elapsed = {};
+  const startAtAllIncludes = process.hrtime();
+  item._include = [];
+
+  return Promise.all(
+    includeSchema.map(childSchema => {
+      const startAtThisInclude = process.hrtime();
+      return populateAddChild(options, hook, item, childSchema, depth)
+        .then(result => {
+          const nameAs = childSchema.nameAs || childSchema.service;
+          elapsed[nameAs] = getElapsed(options, startAtThisInclude, depth);
+
+          return result;
+        });
+    })
+  )
+    .then(children => {
+      // 'children' is like [{ authorInfo: {...}, readersInfo: [{...}, {...}] }]
+      if (options.profile !== false) {
+        elapsed.total = getElapsed(options, startAtAllIncludes, depth);
+        item._elapsed = elapsed;
+      }
+
+      return Object.assign(item, ...children);
+    });
+}
+
+function populateAddChild (options, hook, parentItem, childSchema, depth) {
+  /*
+  'parentItem' is the item we are adding children to
+  'childSchema' is like
+    { service: 'comments',
+      permissions: '...',
+      nameAs: 'comments',
+      asArray: true,
+      parentField: 'id',
+      childField: 'postId',
+      query: { $limit: 5, $select: ['title', 'content', 'postId'], $sort: { createdAt: -1 } },
+      select: (hook, parent, depth) => ({ something: { $exists: false }}),
+      include: [ ... ],
+    }
+  */
+
+  // note: parentField & childField are req'd, plus parentItem[parentField} !== undefined .
+  // childSchema.select may override their relationship but some relationship must be given.
+  if (!childSchema.service || !childSchema.parentField || !childSchema.childField) {
+    throw new errors.BadRequest('Child schema is missing a required property. (populate)');
+  }
+
+  if (childSchema.permissions &&
+    !options.checkPermissions(hook, childSchema.service, childSchema.permissions, depth)
+  ) {
+    throw new errors.BadRequest(
+      `Permissions for ${childSchema.service} do not allow include. (populate)`
+    );
+  }
+
+  const nameAs = childSchema.nameAs || childSchema.service;
+  parentItem._include.push(nameAs);
+
+  let promise = Promise.resolve()
+    .then(() => (childSchema.select ? childSchema.select(hook, parentItem, depth) : {}))
+    .then(selectQuery => {
+      const parentVal = getByDot(parentItem, childSchema.parentField);
+
+      if (parentVal === undefined) {
+        throw new errors.BadRequest(
+          `ParentField ${childSchema.parentField} for ${nameAs} depth ${depth} is undefined. (populate)`
+        );
+      }
+
+      const query = Object.assign({},
+        childSchema.query,
+        { [childSchema.childField]: Array.isArray(parentVal) ? { $in: parentVal } : parentVal },
+        selectQuery // dynamic options override static ones
+      );
+
+      const serviceHandle = hook.app.service(childSchema.service);
+
+      if (!serviceHandle) {
+        throw new errors.BadRequest(`Service ${childSchema.service} is not configured. (populate)`);
+      }
+
+      return serviceHandle.find({ query, _populate: 'skip' });
+    })
+    .then(result => {
+      result = result.data || result;
+
+      if (result.length === 1 && !childSchema.asArray) {
+        result = result[0];
+      }
+
+      return result;
+    });
+
+  if (childSchema.include) {
+    promise = promise
+      .then(items => populateItemArray(options, hook, items, childSchema.include, depth));
+  }
+
+  return promise
+    .then(items => ({ [nameAs]: items }));
+}
+
+// Helpers
+
+function getElapsed (options, startHrtime, depth) {
+  if (options.profile === true) {
+    const elapsed = process.hrtime(startHrtime);
+    return elapsed[0] * 1e9 + elapsed[1];
+  } else if (options.profile !== false) {
+    return depth; // for testing _elapsed
+  }
+}

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,5 +1,5 @@
 
-import { getItems, replaceItems, getByDot, setByDot } from 'feathers-hooks-common/lib/utils';
+import { getItems, replaceItems, getByDot, setByDot } from './utils';
 
 export const serialize = schema => hook => {
   schema = typeof schema === 'function' ? schema(hook) : schema;

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -1,0 +1,54 @@
+
+import { getItems, replaceItems, getByDot, setByDot } from 'feathers-hooks-common/lib/utils';
+
+export const serialize = schema => hook => {
+  schema = typeof schema === 'function' ? schema(hook) : schema;
+  const schemaDirectives = ['computed', 'exclude', 'only'];
+
+  replaceItems(hook, serializeItems(getItems(hook), schema));
+  return hook;
+
+  function serializeItems (items, schema) {
+    if (!Array.isArray(items)) {
+      return serializeItem(items, schema);
+    }
+
+    return items.map(item => serializeItem(item, schema));
+  }
+
+  function serializeItem (item, schema) {
+    const computed = {};
+    Object.keys(schema.computed || {}).forEach(name => {
+      computed[name] = schema.computed[name](item, hook); // needs closure
+    });
+
+    let only = schema.only;
+    only = typeof only === 'string' ? [only] : only;
+    if (only) {
+      const newItem = {};
+      only.concat('_include', '_elapsed', item._include || []).forEach(key => {
+        setByDot(newItem, key, getByDot(item, key), true);
+      });
+      item = newItem;
+    }
+
+    let exclude = schema.exclude;
+    exclude = typeof exclude === 'string' ? [exclude] : exclude;
+    if (exclude) {
+      exclude.forEach(key => {
+        setByDot(item, key, undefined, true);
+      });
+    }
+
+    const _computed = Object.keys(computed);
+    item = Object.assign({}, item, computed, _computed.length ? { _computed } : {});
+
+    Object.keys(schema).forEach(key => {
+      if (!schemaDirectives.includes(key) && typeof item[key] === 'object') { // needs closure
+        item[key] = serializeItems(item[key], schema[key]);
+      }
+    });
+
+    return item;
+  }
+};

--- a/test/dePopulate.test.js
+++ b/test/dePopulate.test.js
@@ -1,0 +1,144 @@
+
+const assert = require('assert');
+const { dePopulate } = require('../src');
+
+describe('dePopulate', () => {
+  let hookAfter;
+  let hookBeforeArray;
+  let hookBefore;
+
+  beforeEach(() => {
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: {provider: 'rest'},
+      result: {
+        userId: 'as61389dadhga62343hads6712',
+        postId: 1,
+        updatedAt: 1480793101475,
+        _include: ['post', 'x'],
+        _elapsed: { post: 16051500, total: 20707798, x: 1 },
+        _computed: ['a1', 'a1'],
+        a1: 1,
+        post: {
+          id: 1,
+          title: 'Post 1',
+          content: 'Lorem ipsum dolor sit amet 4',
+          author: 'as61389dadhga62343hads6712',
+          readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+          createdAt: 1480793101559
+        }
+      }
+    };
+    hookBefore = {
+      type: 'before',
+      method: 'update',
+      params: {provider: 'rest'},
+      data: {
+        userId: 'as61389dadhga62343hads6712',
+        postId: 1,
+        updatedAt: 1480793101475
+      }
+    };
+    hookBeforeArray = {
+      type: 'before',
+      method: 'patch',
+      params: { provider: 'rest' },
+      data: [
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 1,
+          updatedAt: 1480793101475,
+          _include: ['post'],
+          _elapsed: {post: 3456238, total: 3642135},
+          post: {
+            id: 1,
+            title: 'Post 1',
+            content: 'Lorem ipsum dolor sit amet 4',
+            author: 'as61389dadhga62343hads6712',
+            readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+            createdAt: 1480793101559
+          }
+        },
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 2,
+          updatedAt: 1480793101475,
+          _include: ['post'],
+          _elapsed: {post: 3457496, total: 3878535},
+          post: {
+            id: 2,
+            title: 'Post 2',
+            content: 'Lorem ipsum dolor sit amet 5',
+            author: '167asdf3689348sdad7312131s',
+            readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+            createdAt: 1480793101559
+          }
+        },
+        {
+          userId: '167asdf3689348sdad7312131s',
+          postId: 1,
+          updatedAt: 1480793101475,
+          _include: ['post'],
+          _elapsed: {post: 3446912, total: 3857237},
+          post: {
+            id: 1,
+            title: 'Post 1',
+            content: 'Lorem ipsum dolor sit amet 4',
+            author: 'as61389dadhga62343hads6712',
+            readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+            createdAt: 1480793101559
+          }
+        }
+      ]
+    };
+  });
+
+  it('one item, after hook, missing props', () => {
+    const hook = clone(hookAfter);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.result, {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475
+    });
+  });
+
+  it('one item, before hook, not populated', () => {
+    const hook = clone(hookBefore);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.data, {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475
+    });
+  });
+
+  it('item array, before hook', () => {
+    const hook = clone(hookBeforeArray);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.data,
+      [
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 1,
+          updatedAt: 1480793101475
+        },
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 2,
+          updatedAt: 1480793101475
+        },
+        {
+          userId: '167asdf3689348sdad7312131s',
+          postId: 1,
+          updatedAt: 1480793101475
+        }
+      ]
+    );
+  });
+});
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/helpers/configApp.js
+++ b/test/helpers/configApp.js
@@ -1,0 +1,42 @@
+
+const feathers = require('feathers');
+const memory = require('feathers-memory');
+const feathersHooks = require('feathers-hooks');
+const getInitDb = require('./getInitDb');
+
+module.exports = function (dbNames) {
+  dbNames = typeof dbNames === 'string' ? [dbNames] : dbNames;
+  const serviceConfigs = {
+    users,
+    comments,
+    posts,
+    recommendation
+  };
+
+  return feathers()
+    .configure(feathersHooks())
+    .configure(services);
+
+  function services () {
+    dbNames.forEach(name => {
+      // console.log(`configure service ${name}`);
+      this.configure(serviceConfigs[name]);
+    });
+  }
+
+  function users () {
+    this.use('users', memory(getInitDb('users')));
+  }
+
+  function comments () {
+    this.use('comments', memory(getInitDb('comments')));
+  }
+
+  function posts () {
+    this.use('posts', memory(getInitDb('posts')));
+  }
+
+  function recommendation () {
+    this.use('recommendation', memory(getInitDb('recommendation')));
+  }
+};

--- a/test/helpers/getInitDb.js
+++ b/test/helpers/getInitDb.js
@@ -1,0 +1,92 @@
+
+module.exports = function (name) {
+  const users = {
+    '0': {id: 'as61389dadhga62343hads6712', name: 'Author 1', email: 'author1@posties.com', password: '2347wjkadhad8y7t2eeiudhd98eu2rygr', age: 55},
+    '1': {id: '167asdf3689348sdad7312131s', name: 'Author 2', email: 'author2@posties.com', password: '2347wjkadhad8y7t2eeiudhd98eu2rygr', age: 16}
+  };
+
+  const comments = {
+    '1': {
+      id: 1,
+      postId: 1,
+      title: 'Comment 1',
+      content: 'Lorem ipsum dolor sit amet 1',
+      author: 'as61389dadhga62343hads6712',
+      createdAt: 1480793101559
+    },
+    '2': {
+      id: 2,
+      postId: 2,
+      title: 'Comment 2',
+      content: 'Lorem ipsum dolor sit amet 2',
+      author: 'as61389dadhga62343hads6712',
+      createdAt: 1480793101559
+    },
+    '3': {
+      id: 3,
+      postId: 1,
+      title: 'Comment 3',
+      content: 'Lorem ipsum dolor sit amet 3',
+      author: '167asdf3689348sdad7312131s',
+      createdAt: 1480793101559
+    }
+  };
+
+  const posts = {
+    '1': {
+      id: 1,
+      title: 'Post 1',
+      content: 'Lorem ipsum dolor sit amet 4',
+      author: 'as61389dadhga62343hads6712',
+      readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+      createdAt: 1480793101559
+    },
+    '2': {
+      id: 2,
+      title: 'Post 2',
+      content: 'Lorem ipsum dolor sit amet 5',
+      author: '167asdf3689348sdad7312131s',
+      readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+      createdAt: 1480793101559
+    },
+    '3': {
+      id: 3,
+      title: 'Post 3',
+      content: 'Lorem ipsum dolor sit amet 5',
+      author: '167asdf3689348sdad7312131s',
+      readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+      createdAt: 1480793101559
+    }
+  };
+
+  const recommendation = {
+    '1': {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475
+    },
+    '2': {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 2,
+      updatedAt: 1480793101475
+    },
+    '3': {
+      userId: '167asdf3689348sdad7312131s',
+      postId: 1,
+      updatedAt: 1480793101475
+    }
+  };
+
+  const dbs = {
+    users,
+    comments,
+    posts,
+    recommendation
+  };
+
+  // console.log(`returning db for ${name}`);
+  return {
+    store: dbs[name],
+    idField: '_id'
+  };
+};

--- a/test/legacyPopulate.test.js
+++ b/test/legacyPopulate.test.js
@@ -1,0 +1,261 @@
+if (!global._babelPolyfill) { require('babel-polyfill'); }
+
+import { assert } from 'chai';
+import hooks from '../src';
+import feathersFakes from 'feathers-tests-fake-app-users';
+
+const fakeUsersDb = [ // faked in-memory database
+  { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' },
+  { _id: 'b', name: 'Jane Doe', isVerified: true, password: 'secret' }
+];
+const fakeMessagesDb = [ // faked in-memory database
+  { _id: '1', senderId: 'a', text: 'Jane, are you there?' },
+  { _id: '2', senderId: 'b', text: 'I am. How are you?' },
+  { _id: '3', senderId: 'a', text: 'Fine, and you?' },
+  { _id: '4', senderId: 'b', text: 'Fine too?' }
+];
+
+describe('legacyPopulate', () => {
+  var usersDb;
+  var messagesDb;
+  var app;
+  var hookA;
+  var hookMulti;
+  var hookBad;
+  var hookNonPaginated;
+  var hookPaginated;
+
+  beforeEach(() => {
+    usersDb = clone(fakeUsersDb);
+    messagesDb = clone(fakeMessagesDb);
+    app = feathersFakes.app(); // stub feathers app
+    const usersService = feathersFakes.makeDbService(app, 'users', usersDb);
+    const messagesService = feathersFakes.makeDbService(app, 'messages', messagesDb);
+    app.use('/users', usersService);
+    app.use('/messages', messagesService);
+
+    // Emulate a remove('password') after hook on /users
+    const usersGet = app.service('/users').get;
+    app.service('/users').get = (id, params) => {
+      return usersGet(id, params).then(user => {
+        if (user && !!params.provider) {
+          delete user.password;
+        }
+        return user;
+      });
+    };
+
+    hookA = {
+      type: 'after',
+      method: 'create',
+      app,
+      result: { _id: '5', senderId: 'a', text: 'I\'m eating an ice cream.' }
+    };
+    hookMulti = {
+      type: 'after',
+      method: 'create',
+      app,
+      result: { _id: '5', senderId: ['a', 'b'], text: 'I\'m eating an ice cream.' }
+    };
+    hookNonPaginated = {
+      type: 'after',
+      method: 'create',
+      app,
+      result: [
+        { _id: '1', senderId: 'a', text: 'Jane, are you there?' },
+        { _id: '2', senderId: 'b', text: 'I am. How are you?' }
+      ]
+    };
+    hookPaginated = {
+      type: 'after',
+      method: 'find',
+      app,
+      result: { data: [
+        { _id: '1', senderId: 'a', text: 'Jane, are you there?' },
+        { _id: '2', senderId: 'b', text: 'I am. How are you?' }
+      ] }
+    };
+    hookBad = {
+      type: 'after',
+      method: 'create',
+      app,
+      result: { _id: '5', senderId: 'no-suc-id', text: 'I\'m eating an ice cream.' }
+    };
+  });
+
+  describe('test fakes', () => {
+    it('fakes built correctly', () => {
+      const users = app.service('/users');
+      const messages = app.service('/messages');
+      assert.isFunction(users.create);
+      assert.isFunction(messages.find);
+    });
+
+    it('finds items correctly', (next) => {
+      const messages = app.service('/messages');
+      messages.find({ query: { senderId: 'a' } }).then(result => {
+        const data = result.data;
+        assert.equal(data.length, 2);
+        next();
+      });
+    });
+  });
+
+  describe('uses options.field as key, target for populated fields', () => {
+    it('populates an item with another which exists', (next) => {
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookA)
+        .then(hook => {
+          assert.deepEqual(hook.result, {
+            _id: '5',
+            senderId: 'a',
+            text: 'I\'m eating an ice cream.',
+            user: { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' }
+          });
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err);
+        });
+    });
+    it('does not populate an item with another that does not exist', (next) => {
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookBad)
+        .then(hook => {
+          console.log('unexpectedly succeeded.');
+        })
+        .catch(() => {
+          next();
+        });
+    });
+  });
+
+  describe('target is default for option.field', () => {
+    it('populates an item with another which exists', (next) => {
+      hooks.populate('senderId', { service: '/users' })(hookA)
+        .then(hook => {
+          assert.deepEqual(hook.result, {
+            _id: '5',
+            senderId: { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' },
+            text: 'I\'m eating an ice cream.'
+          });
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err.message);
+        });
+    });
+    it('does not populate an item with another that does not exist', (next) => {
+      hooks.populate('senderId', { service: '/users' })(hookBad)
+        .then(hook => {
+          console.log('unexpectedly succeeded.');
+        })
+        .catch(() => {
+          next();
+        });
+    });
+    it('does return same item if populate an item with no options.field', (next) => {
+      hooks.populate('sender', { service: '/users' })(hookA)
+        .then(hook => {
+          assert.strictEqual(hook.result, hookA.result);
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err.message);
+        });
+    });
+  });
+
+  describe('populates an array of results', () => {
+    it('non-paginated for any method', (next) => {
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookNonPaginated)
+        .then(hook => {
+          assert.deepEqual(hook.result, [
+            { _id: '1',
+              senderId: 'a',
+              text: 'Jane, are you there?',
+              user: { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' } },
+            { _id: '2',
+              senderId: 'b',
+              text: 'I am. How are you?',
+              user: { _id: 'b', name: 'Jane Doe', isVerified: true, password: 'secret' } }
+          ]);
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err);
+        });
+    });
+
+    it('paginated if necessary for find method', (next) => {
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookPaginated)
+        .then(hook => {
+          assert.deepEqual(hook.result, { data: [
+            { _id: '1',
+              senderId: 'a',
+              text: 'Jane, are you there?',
+              user: { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' } },
+            { _id: '2',
+              senderId: 'b',
+              text: 'I am. How are you?',
+              user: { _id: 'b', name: 'Jane Doe', isVerified: true, password: 'secret' } }
+          ] });
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err);
+        });
+    });
+  });
+
+  describe('populates with multiple ids', () => {
+    it('in one item', (next) => {
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookMulti)
+        .then(hook => {
+          assert.deepEqual(hook.result, {
+            _id: '5',
+            senderId: ['a', 'b'],
+            text: 'I\'m eating an ice cream.',
+            user: [
+              { _id: 'a', name: 'John Doe', isVerified: false, password: 'secret' },
+              { _id: 'b', name: 'Jane Doe', isVerified: true, password: 'secret' }
+            ]
+          });
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err);
+        });
+    });
+  });
+
+  describe('populates depending on provider', () => {
+    it('does remove password if non-internal provider', (next) => {
+      hookA.params = { provider: 'rest' };
+      hooks.populate('user', { field: 'senderId', service: '/users' })(hookA)
+        .then(hook => {
+          assert.deepEqual(hook.result, {
+            _id: '5',
+            senderId: 'a',
+            text: 'I\'m eating an ice cream.',
+            user: { _id: 'a', name: 'John Doe', isVerified: false }
+          });
+          next();
+        })
+        .catch(err => {
+          console.log('unexpectedly failed.');
+          console.log(err);
+        });
+    });
+  });
+});
+
+// Helpers
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/populate-1deep-1child.test.js
+++ b/test/populate-1deep-1child.test.js
@@ -1,0 +1,273 @@
+
+const chai = require('chai');
+const configApp = require('../test/helpers/configApp');
+const getInitDb = require('../test/helpers/getInitDb');
+const { populate } = require('../src');
+
+const assert = chai.assert;
+
+describe('populate - include 1:1', () => {
+  let hookAfter;
+  let hookAfterArray;
+
+  let app;
+  let recommendation;
+
+  beforeEach(() => {
+    app = configApp(['posts', 'recommendation']);
+    recommendation = clone(getInitDb('recommendation').store);
+
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      path: 'recommendations',
+      result: recommendation['1']
+    };
+    hookAfterArray = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      path: 'recommendations',
+      result: [recommendation['1'], recommendation['2'], recommendation['3']]
+    };
+  });
+
+  describe('root is one item', () => {
+    it('saves in nameAs', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            nameAs: 'post',
+            parentField: 'postId', // we have no test for dot notation 'cause no such data
+            childField: 'id'
+          }
+        ]
+      };
+
+      return populate({ schema })(hook)
+        .then(hook1 => {
+          const expected = recommendationPosts('post');
+          assert.deepEqual(hook1.result, expected);
+        });
+    });
+
+    it('saves in service as default', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id'
+          }
+        ]
+      };
+
+      return populate({ schema })(hook)
+        .then(hook1 => {
+          const expected = recommendationPosts('posts');
+          assert.deepEqual(hook1.result, expected);
+        });
+    });
+
+    it('uses asArray', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            asArray: true
+          }
+        ]
+      };
+
+      return populate({ schema })(hook)
+        .then(hook1 => {
+          const expected = recommendationPosts('posts', true);
+          assert.deepEqual(hook1.result, expected);
+        });
+    });
+
+    it('query overridden by childField', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            query: { id: 'aaaaaa' }
+          }
+        ]
+      };
+
+      return populate({ schema })(hook)
+        .then(hook1 => {
+          const expected = recommendationPosts('posts');
+          assert.deepEqual(hook1.result, expected);
+        });
+    });
+
+    it('childField overridden by select', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            parentField: 'updatedAt',
+            childField: 'id',
+            select: (hook, parent) => ({ id: parent.postId })
+          }
+        ]
+      };
+
+      return populate({ schema })(hook)
+        .then(hook1 => {
+          const expected = recommendationPosts('posts');
+          assert.deepEqual(hook1.result, expected);
+        });
+    });
+
+    it('checks permissions', () => {
+      let spy = [];
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const checkPermissions = (hook, service, permissions, depth) => {
+        spy.push({ service, permissions, depth });
+        return true;
+      };
+
+      const schema = {
+        permissions: 'for root',
+        include: [
+          {
+            service: 'posts',
+            nameAs: 'post',
+            parentField: 'postId',
+            childField: 'id',
+            permissions: 'for posts'
+          }
+        ]
+      };
+
+      return populate({ schema, checkPermissions })(hook)
+        .then(hook1 => {
+          let expected = recommendationPosts('post');
+          assert.deepEqual(hook1.result, expected);
+
+          expected = [
+            { service: 'recommendations', permissions: 'for root', depth: 0 },
+            { service: 'posts', permissions: 'for posts', depth: 1 }
+          ];
+          assert.deepEqual(spy, expected);
+        });
+    });
+
+    it('throws on invalid permissions', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const checkPermissions = (hook, service, permissions, depth) => {
+        return depth === 0;
+      };
+
+      const schema = {
+        permissions: 'for root',
+        include: [
+          {
+            service: 'posts',
+            nameAs: 'post',
+            parentField: 'postId',
+            childField: 'id',
+            permissions: 'for posts'
+          }
+        ]
+      };
+
+      return populate({ schema, checkPermissions })(hook)
+        .then(() => { throw new Error('was not supposed to succeed'); })
+        .catch(() => {});
+    });
+
+    it('stores elapsed time', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            nameAs: 'post',
+            parentField: 'postId',
+            childField: 'id'
+          }
+        ]
+      };
+
+      return populate({ schema, profile: true })(hook)
+        .then(hook1 => {
+          const elapsed = hook1.result._elapsed;
+          assert.deepEqual(Object.keys(elapsed), ['post', 'total']);
+          assert.isAbove(elapsed.total, 1000);
+          assert.isAtLeast(elapsed.total, elapsed.post);
+        });
+    });
+  });
+
+  describe('root is item array', () => {
+    it('populates each item', () => {
+      const hook = clone(hookAfterArray);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      const schema = {
+        include: [
+          {
+            service: 'posts',
+            nameAs: 'post',
+            parentField: 'postId',
+            childField: 'id'
+          }
+        ]
+      };
+
+      return populate({ schema, profile: true })(hook)
+        .then(hook1 => {
+          assert.equal(hook1.result.length, 3);
+        });
+    });
+  });
+});
+
+// Helpers
+
+function recommendationPosts (nameAs, asArray, recommendation, posts) {
+  recommendation = recommendation || clone(getInitDb('recommendation').store['1']);
+  posts = posts || clone(getInitDb('posts').store['1']);
+
+  const expected = clone(recommendation);
+  expected._include = [nameAs];
+
+  expected[nameAs] = asArray ? [clone(posts)] : clone(posts);
+
+  return expected;
+}
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/populate-1deep-1child.test.js
+++ b/test/populate-1deep-1child.test.js
@@ -202,7 +202,7 @@ describe('populate - include 1:1', () => {
 
       return populate({ schema, checkPermissions })(hook)
         .then(() => { throw new Error('was not supposed to succeed'); })
-        .catch(() => {});
+        .catch(err => { assert.notEqual(err, undefined); });
     });
 
     it('stores elapsed time', () => {

--- a/test/populate-basics.test.js
+++ b/test/populate-basics.test.js
@@ -71,21 +71,21 @@ describe('populate - throws on bad params', () => { // run to increase code clim
     const hook = clone(hookAfter);
     return populate({ schema: 1 })(hook)
       .then(() => { throw new Error('was not supposed to succeed'); })
-      .catch(() => {});
+      .catch(err => { assert.notEqual(err, undefined); });
   });
 
   it('permissions not func', () => {
     const hook = clone(hookAfter);
     return populate({ schema: {}, checkPermissions: 1 })(hook)
       .then(() => { throw new Error('was not supposed to succeed'); })
-      .catch(() => {});
+      .catch(err => { assert.notEqual(err, undefined); });
   });
 
   it('throws on invalid permissions', () => {
     const hook = clone(hookAfter);
     return populate({ schema: {}, checkPermissions: () => false })(hook)
       .then(() => { throw new Error('was not supposed to succeed'); })
-      .catch(() => {});
+      .catch(err => { assert.notEqual(err, undefined); });
   });
 });
 

--- a/test/populate-basics.test.js
+++ b/test/populate-basics.test.js
@@ -1,0 +1,94 @@
+
+const assert = require('assert');
+const { populate } = require('../src');
+
+describe('populate - finds items in hook', () => {
+  let hookAfter;
+  let hookAfterArray;
+  let hookFindPaginate;
+
+  beforeEach(() => {
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      result: { first: 'Jane2', last: 'Doe2' } };
+    hookAfterArray = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      result: [{ first: 'John2', last: 'Doe2' }, { first: 'Jane', last: 'Doe' }] };
+    hookFindPaginate = {
+      type: 'after',
+      method: 'find',
+      params: { provider: 'rest' },
+      result: {
+        total: 2,
+        data: [
+          { first: 'John3', last: 'Doe3' },
+          { first: 'Jane3', last: 'Doe3' }
+        ]
+      } };
+  });
+
+  it('one item', () => {
+    const hook = clone(hookAfter);
+    return populate({ schema: {} })(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('item array', () => {
+    const hook = clone(hookAfterArray);
+    return populate({ schema: {} })(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfterArray);
+      });
+  });
+
+  it('find paginated', () => {
+    const hook = clone(hookFindPaginate);
+    return populate({ schema: {} })(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookFindPaginate);
+      });
+  });
+});
+
+describe('populate - throws on bad params', () => { // run to increase code climate score
+  let hookAfter;
+
+  beforeEach(() => {
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      result: { first: 'Jane2', last: 'Doe2' } };
+  });
+
+  it('schema', () => {
+    const hook = clone(hookAfter);
+    return populate({ schema: 1 })(hook)
+      .then(() => { throw new Error('was not supposed to succeed'); })
+      .catch(() => {});
+  });
+
+  it('permissions not func', () => {
+    const hook = clone(hookAfter);
+    return populate({ schema: {}, checkPermissions: 1 })(hook)
+      .then(() => { throw new Error('was not supposed to succeed'); })
+      .catch(() => {});
+  });
+
+  it('throws on invalid permissions', () => {
+    const hook = clone(hookAfter);
+    return populate({ schema: {}, checkPermissions: () => false })(hook)
+      .then(() => { throw new Error('was not supposed to succeed'); })
+      .catch(() => {});
+  });
+});
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/populate-relations.test.js
+++ b/test/populate-relations.test.js
@@ -1,0 +1,253 @@
+
+const assert = require('assert');
+const configApp = require('../test/helpers/configApp');
+const getInitDb = require('../test/helpers/getInitDb');
+const { populate } = require('../src');
+
+describe('populate - 1:1 & 1:m & m:1', () => {
+  let hookAfter;
+  let hookAfterArray;
+  let schema;
+
+  let app;
+  let recommendation;
+
+  beforeEach(() => {
+    app = configApp(['recommendation', 'posts', 'users', 'comments']);
+    recommendation = clone(getInitDb('recommendation').store);
+
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      path: 'recommendations',
+      result: recommendation['1']
+    };
+    hookAfterArray = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      path: 'recommendations',
+      result: [recommendation['1'], recommendation['2'], recommendation['3']]
+    };
+
+    schema = {
+      permissions: '',
+      include: [
+        {
+          service: 'posts',
+          nameAs: 'post',
+          parentField: 'postId',
+          childField: 'id',
+          include: [
+            { // 1:1
+              service: 'users',
+              permissions: '',
+              nameAs: 'authorInfo',
+              parentField: 'author',
+              childField: 'id'
+            },
+            { // 1:m
+              service: 'comments',
+              permissions: '',
+              nameAs: 'commentsInfo',
+              parentField: 'id',
+              childField: 'postId',
+              select: (hook, parent) => ({ $limit: 6 }),
+              asArray: true,
+              query: {
+                $limit: 5,
+                $select: ['title', 'content', 'postId'],
+                $sort: {createdAt: -1}
+              }
+            },
+            { // m:1
+              service: 'users',
+              permissions: '',
+              nameAs: 'readersInfo',
+              parentField: 'readers',
+              childField: 'id'
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  it('for one item', () => {
+    const hook = clone(hookAfter);
+    hook.app = app; // app is a func and wouldn't be cloned
+
+    return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
+      .then(hook1 => {
+        assert.deepEqual(hook1.result,
+          { userId: 'as61389dadhga62343hads6712',
+            postId: 1,
+            updatedAt: 1480793101475,
+            _include: [ 'post' ],
+            _elapsed: { post: 1, total: 1 },
+            post:
+            { id: 1,
+              title: 'Post 1',
+              content: 'Lorem ipsum dolor sit amet 4',
+              author: 'as61389dadhga62343hads6712',
+              readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+              createdAt: 1480793101559,
+              _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+              _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+              authorInfo:
+              { id: 'as61389dadhga62343hads6712',
+                name: 'Author 1',
+                email: 'author1@posties.com',
+                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                age: 55 },
+              commentsInfo:
+                [ { title: 'Comment 1',
+                  content: 'Lorem ipsum dolor sit amet 1',
+                  postId: 1 },
+                  { title: 'Comment 3',
+                    content: 'Lorem ipsum dolor sit amet 3',
+                    postId: 1 } ],
+              readersInfo:
+                [ { id: 'as61389dadhga62343hads6712',
+                  name: 'Author 1',
+                  email: 'author1@posties.com',
+                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                  age: 55 },
+                  { id: '167asdf3689348sdad7312131s',
+                    name: 'Author 2',
+                    email: 'author2@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 16 } ] } }
+        );
+      });
+  });
+
+  it('for an item array', () => {
+    const hook = clone(hookAfterArray);
+    hook.app = app; // app is a func and wouldn't be cloned
+
+    return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
+      .then(hook1 => {
+        assert.deepEqual(hook1.result,
+          [ { userId: 'as61389dadhga62343hads6712',
+            postId: 1,
+            updatedAt: 1480793101475,
+            _include: [ 'post' ],
+            _elapsed: { post: 1, total: 1 },
+            post:
+            { id: 1,
+              title: 'Post 1',
+              content: 'Lorem ipsum dolor sit amet 4',
+              author: 'as61389dadhga62343hads6712',
+              readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+              createdAt: 1480793101559,
+              _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+              _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+              authorInfo:
+              { id: 'as61389dadhga62343hads6712',
+                name: 'Author 1',
+                email: 'author1@posties.com',
+                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                age: 55 },
+              commentsInfo:
+                [ { title: 'Comment 1',
+                  content: 'Lorem ipsum dolor sit amet 1',
+                  postId: 1 },
+                  { title: 'Comment 3',
+                    content: 'Lorem ipsum dolor sit amet 3',
+                    postId: 1 } ],
+              readersInfo:
+                [ { id: 'as61389dadhga62343hads6712',
+                  name: 'Author 1',
+                  email: 'author1@posties.com',
+                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                  age: 55 },
+                  { id: '167asdf3689348sdad7312131s',
+                    name: 'Author 2',
+                    email: 'author2@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 16 } ] } },
+            { userId: 'as61389dadhga62343hads6712',
+              postId: 2,
+              updatedAt: 1480793101475,
+              _include: [ 'post' ],
+              _elapsed: { post: 1, total: 1 },
+              post:
+              { id: 2,
+                title: 'Post 2',
+                content: 'Lorem ipsum dolor sit amet 5',
+                author: '167asdf3689348sdad7312131s',
+                readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+                createdAt: 1480793101559,
+                _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+                _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+                authorInfo:
+                { id: '167asdf3689348sdad7312131s',
+                  name: 'Author 2',
+                  email: 'author2@posties.com',
+                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                  age: 16 },
+                commentsInfo:
+                  [ { title: 'Comment 2',
+                    content: 'Lorem ipsum dolor sit amet 2',
+                    postId: 2 } ],
+                readersInfo:
+                  [ { id: 'as61389dadhga62343hads6712',
+                    name: 'Author 1',
+                    email: 'author1@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 55 },
+                    { id: '167asdf3689348sdad7312131s',
+                      name: 'Author 2',
+                      email: 'author2@posties.com',
+                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                      age: 16 } ] } },
+            { userId: '167asdf3689348sdad7312131s',
+              postId: 1,
+              updatedAt: 1480793101475,
+              _include: [ 'post' ],
+              _elapsed: { post: 1, total: 1 },
+              post:
+              { id: 1,
+                title: 'Post 1',
+                content: 'Lorem ipsum dolor sit amet 4',
+                author: 'as61389dadhga62343hads6712',
+                readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+                createdAt: 1480793101559,
+                _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+                _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+                authorInfo:
+                { id: 'as61389dadhga62343hads6712',
+                  name: 'Author 1',
+                  email: 'author1@posties.com',
+                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                  age: 55 },
+                commentsInfo:
+                  [ { title: 'Comment 1',
+                    content: 'Lorem ipsum dolor sit amet 1',
+                    postId: 1 },
+                    { title: 'Comment 3',
+                      content: 'Lorem ipsum dolor sit amet 3',
+                      postId: 1 } ],
+                readersInfo:
+                  [ { id: 'as61389dadhga62343hads6712',
+                    name: 'Author 1',
+                    email: 'author1@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 55 },
+                    { id: '167asdf3689348sdad7312131s',
+                      name: 'Author 2',
+                      email: 'author2@posties.com',
+                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                      age: 16 } ] } } ]
+        );
+      });
+  });
+});
+
+// Helpers
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/populate-scaffolding.test.js
+++ b/test/populate-scaffolding.test.js
@@ -1,0 +1,34 @@
+
+const assert = require('assert');
+const configApp = require('../test/helpers/configApp');
+
+describe('populate - test scaffolding', () => {
+  it('can reinitialize database', done => {
+    const app = configApp(['users', 'comments', 'posts', 'recommendation']);
+    const users = app.service('users');
+
+    users.find({ query: {} })
+      .then(data => {
+        assert.equal(data.length, 2);
+      })
+      .then(() => {
+        return users.remove(0);
+      })
+      .then(() => {
+        return users.find({query: {}});
+      })
+      .then(data => {
+        assert.equal(data.length, 1);
+      })
+      .then(() => {
+        const app1 = configApp(['users', 'comments', 'posts', 'recommendation']);
+        const users1 = app1.service('users');
+
+        return users1.find({query: {}});
+      })
+      .then(data => {
+        assert.equal(data.length, 2);
+        done();
+      });
+  });
+});

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -1,0 +1,136 @@
+
+const assert = require('assert');
+const { serialize } = require('../src');
+
+describe('serialize', () => {
+  let hookAfter;
+  let schema;
+
+  beforeEach(() => {
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: { provider: 'rest' },
+      path: 'recommendations',
+      result: {}
+    };
+
+    schema = {
+      only: ['updatedAt'],
+      computed: {
+        commentsCount: (recommendation, hook) => recommendation.post.commentsInfo.length
+      },
+      post: {
+        exclude: ['id', 'createdAt', 'author', 'readers', '_id'],
+        authorInfo: {
+          exclude: ['id', 'password', '_id', 'age'],
+          computed: {
+            isUnder18: (authorInfo, hook) => authorInfo.age < 18
+          }
+        },
+        readersInfo: {
+          exclude: 'id'
+        },
+        commentsInfo: {
+          only: ['title', 'content'],
+          exclude: 'content'
+        }
+      }
+    };
+  });
+
+  it('for one item', () => {
+    const hook = clone(hookAfter);
+    hook.result = { userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475,
+      _include: [ 'post' ],
+      _elapsed: { post: 1, total: 1 },
+      post:
+      { id: 1,
+        title: 'Post 1',
+        content: 'Lorem ipsum dolor sit amet 4',
+        author: 'as61389dadhga62343hads6712',
+        readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+        createdAt: 1480793101559,
+        _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+        _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+        authorInfo: {
+          id: 'as61389dadhga62343hads6712',
+          name: 'Author 1',
+          email: 'author1@posties.com',
+          password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+          age: 55
+        },
+        commentsInfo:
+        [
+            { title: 'Comment 1',
+              content: 'Lorem ipsum dolor sit amet 1',
+              postId: 1 },
+            { title: 'Comment 3',
+              content: 'Lorem ipsum dolor sit amet 3',
+              postId: 1 }
+        ],
+        readersInfo:
+        [
+            { id: 'as61389dadhga62343hads6712',
+              name: 'Author 1',
+              email: 'author1@posties.com',
+              password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+              age: 55 },
+            { id: '167asdf3689348sdad7312131s',
+              name: 'Author 2',
+              email: 'author2@posties.com',
+              password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+              age: 16 }
+        ]
+      }
+    };
+
+    const hook1 = serialize(schema)(hook);
+
+    assert.deepEqual(hook1,
+      { type: 'after',
+        method: 'create',
+        params: { provider: 'rest' },
+        path: 'recommendations',
+        result: {
+          updatedAt: 1480793101475,
+          _include: [ 'post' ],
+          _elapsed: { post: 1, total: 1 },
+          post: {
+            title: 'Post 1',
+            content: 'Lorem ipsum dolor sit amet 4',
+            _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+            _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+            authorInfo: {
+              name: 'Author 1',
+              email: 'author1@posties.com',
+              isUnder18: false,
+              _computed: [ 'isUnder18' ]
+            },
+            commentsInfo: [ { title: 'Comment 1' }, { title: 'Comment 3' } ],
+            readersInfo: [
+              { name: 'Author 1',
+                email: 'author1@posties.com',
+                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                age: 55 },
+              { name: 'Author 2',
+                email: 'author2@posties.com',
+                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                age: 16 }
+            ]
+          },
+          commentsCount: 2,
+          _computed: [ 'commentsCount' ]
+        }
+      }
+    );
+  });
+});
+
+// Helpers
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
- Docs are in github eddyystop/feathers-hooks-populate for the moment.
- Old populate hook renamed legacyPopulate.
- New populate calls legacyPopulate based on func signature for backward compatibility.
- @marshall reviewed the README and pushed a PR.
- @ekryski "took a quick gander as well and it looks pretty good." I assume he looked at the code.
- I'll copy the README to GitBook once the code is reviewed.
- Perhaps these 3 hooks ought to have their own subpage hooks/common/populate
as the docs are not short.