### PR TITLE
adding an every hook

### DIFF
--- a/src/new.js
+++ b/src/new.js
@@ -103,7 +103,7 @@ export const combine = (...rest) => function (hook) {
  * Hook to conditionally execute one or another set of hooks.
  *
  * @param {Function|Promise|boolean} ifFcn - Predicate function(hook).
- * @param {Array.function|Function} trueHooks - Hook functions to execute when ifFcn is truesy.
+ * @param {Array.function|Function} trueHooks - Hook functions to execute when ifFcn is truthy.
  * @param {Array.function|Function} falseHooks - Hook functions to execute when ifFcn is falsey.
  * @returns {Object} resulting hook
  *
@@ -182,6 +182,34 @@ export const iff = (ifFcn, ...rest) => {
  */
 
 export const when = iff;
+
+/**
+ * Hook that executes a set of hooks and returns true if all of
+ * the hooks returns a truthy value and false if one of them does not.
+ *
+ * @param {Array.function} rest - Hook functions to execute.
+ * @returns {Boolean}
+ *
+ * Example 1
+ * service.before({
+ *   create: hooks.every(hook1, hook2, ...) // same as [hook1, hook2, ...]
+ * });
+ *
+ * Example 2 - called within a custom hook function
+ * function (hook) {
+ *   ...
+ *   return hooks.every(hook1, hook2, ...).call(this, currentHook)
+ *     .then(hook => { ... });
+ * }
+ */
+
+export const every = (...rest) => function (hook) {
+  const hooks = rest.map(fn => fn.call(this, hook));
+
+  return Promise.all(hooks).then(results => {
+    return Promise.resolve(results.every(result => !!result));
+  });
+};
 
 /**
  * Predicate to check what called the service method.

--- a/test/every.test.js
+++ b/test/every.test.js
@@ -1,0 +1,96 @@
+
+const assert = require('chai').assert;
+const feathers = require('feathers');
+const memory = require('feathers-memory');
+const feathersHooks = require('feathers-hooks');
+const hooks = require('../src');
+
+describe.only('every', () => {
+  let app;
+
+  beforeEach(() => {
+    app = feathers()
+      .configure(feathersHooks())
+      .use('/users', memory());
+  });
+
+  describe('when all hooks are truthy', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.every(
+                (hook) => true,
+                (hook) => Promise.resolve(true)
+              ),
+              (hook) => Promise.resolve(hook)
+            )
+          ]
+        }
+      });
+    });
+
+    it('returns true', () => {
+      return app.service('users').find().then(result => {
+        assert.deepEqual(result, []);
+      });
+    });
+  });
+
+  describe('when a hook errors', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.every(
+                (hook) => true,
+                (hook) => {
+                  throw new Error('Hook 2 errored');
+                },
+                (hook) => true
+              ),
+              (hook) => Promise.resolve(hook)
+            )
+          ]
+        }
+      });
+    });
+
+    it('rejects with the error', () => {
+      return app.service('users').find().catch(error => {
+        assert.equal(error.message, 'Hook 2 errored');
+      });
+    });
+  });
+
+  describe('when at least one hook is falsey', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.isNot(
+                hooks.every(
+                  (hook) => true,
+                  (hook) => Promise.resolve(true),
+                  (hook) => Promise.resolve(false),
+                  (hook) => false,
+                  (hook) => true,
+                )
+              ),
+              () => Promise.reject(new Error('A hook returned false'))
+            )
+          ]
+        }
+      });
+    });
+
+    it('returns false', () => {
+      return app.service('users').find().catch(error => {
+        assert.equal(error.message, 'A hook returned false');
+      });
+    });
+  });
+});

--- a/test/every.test.js
+++ b/test/every.test.js
@@ -5,7 +5,7 @@ const memory = require('feathers-memory');
 const feathersHooks = require('feathers-hooks');
 const hooks = require('../src');
 
-describe.only('every', () => {
+describe('every', () => {
   let app;
 
   beforeEach(() => {
@@ -22,6 +22,8 @@ describe.only('every', () => {
             hooks.iff(
               hooks.every(
                 (hook) => true,
+                (hook) => 1,
+                (hook) => {},
                 (hook) => Promise.resolve(true)
               ),
               (hook) => Promise.resolve(hook)
@@ -38,7 +40,7 @@ describe.only('every', () => {
     });
   });
 
-  describe('when a hook errors', () => {
+  describe('when a hook throws an error', () => {
     beforeEach(() => {
       app.service('users').hooks({
         before: {
@@ -49,6 +51,31 @@ describe.only('every', () => {
                 (hook) => {
                   throw new Error('Hook 2 errored');
                 },
+                (hook) => true
+              ),
+              (hook) => Promise.resolve(hook)
+            )
+          ]
+        }
+      });
+    });
+
+    it('rejects with the error', () => {
+      return app.service('users').find().catch(error => {
+        assert.equal(error.message, 'Hook 2 errored');
+      });
+    });
+  });
+
+  describe('when a hook rejects with an error', () => {
+    beforeEach(() => {
+      app.service('users').hooks({
+        before: {
+          all: [
+            hooks.iff(
+              hooks.every(
+                (hook) => true,
+                (hook) => Promise.reject(Error('Hook 2 errored')),
                 (hook) => true
               ),
               (hook) => Promise.resolve(hook)
@@ -77,6 +104,9 @@ describe.only('every', () => {
                   (hook) => Promise.resolve(true),
                   (hook) => Promise.resolve(false),
                   (hook) => false,
+                  (hook) => 0,
+                  (hook) => null,
+                  (hook) => undefined,
                   (hook) => true,
                 )
               ),


### PR DESCRIPTION
### Summary

Adding a utility hook that takes in other functions and resolves to `true` if all of the functions return true. Resolves to `false` if one of the functions returns a falsey value. Errors thrown from a hook function (ie. hook2) break out of the chain and are rejected appropriately.

Usage is like so:

```js
every(hook1, hook2, hook3)
````

### Other Information

Related to this discussion https://github.com/feathersjs/feathers-permissions/issues/4