### PR TITLE
adding unless hook

### DIFF
--- a/src/new.js
+++ b/src/new.js
@@ -148,7 +148,7 @@ export const iffElse = (ifFcn, trueHooks, falseHooks) => (hook) => {
  * Hook to conditionally execute one or another set of hooks using function chaining.
  *
  * @param {Function|Promise|boolean} ifFcn - Predicate function(hook).
- * @param {Array.function} rest - Hook functions to execute when ifFcn is truesy.
+ * @param {Array.function} rest - Hook functions to execute when ifFcn is truthy.
  * @returns {Function} iffWithoutElse
  *
  * Examples:
@@ -237,6 +237,32 @@ export const every = (...rest) => function (hook) {
   return Promise.all(hooks).then(results => {
     return Promise.resolve(results.every(result => !!result));
   });
+};
+
+/**
+ * Hook to conditionally execute one or another set of hooks using function chaining.
+ * if the predicate hook function returns a falsey value.
+ * Equivalent to iff(isNot(isProvider), hook1, hook2, hook3).
+ *
+ * @param {Function|Promise|boolean} unlessFcn - Predicate function(hook).
+ * @param {Array.function} rest - Hook functions to execute when unlessFcn is falsey.
+ * @returns {Function} iffWithoutElse
+ *
+ * Examples:
+ * unless(isServer, hookA, hookB)
+ *
+ * unless(isServer,
+ *   hookA,
+ *   unless(isProvider('rest'), hook1, hook2, hook3),
+ *   hookB
+ * )
+ */
+export const unless = (unlessFcn, ...rest) => {
+  if (typeof unlessFcn === 'function') {
+    return iff(isNot(unlessFcn), ...rest);
+  }
+
+  return iff(!unlessFcn, ...rest);
 };
 
 /**

--- a/test/unless.test.js
+++ b/test/unless.test.js
@@ -1,0 +1,408 @@
+if (!global._babelPolyfill) { require('babel-polyfill'); }
+
+import { assert } from 'chai';
+import hooks from '../src';
+
+var hook;
+var hookBefore;
+var hookAfter;
+var hookFcnSyncCalls;
+var hookFcnAsyncCalls;
+var hookFcnCbCalls;
+var predicateHook;
+var predicateOptions;
+var predicateValue;
+
+const predicateSync = (hook) => {
+  predicateHook = clone(hook);
+  return false;
+};
+
+const predicateSync2 = (options) => (hook) => {
+  predicateOptions = clone(options);
+  predicateHook = clone(hook);
+  return false;
+};
+
+const predicateAsync = (hook) => {
+  predicateHook = clone(hook);
+  return new Promise(resolve => resolve(false));
+};
+
+const predicateAsync2 = (options) => (hook) => {
+  predicateOptions = clone(options);
+  predicateHook = clone(hook);
+  return new Promise(resolve => resolve(false));
+};
+
+const predicateAsyncFunny = (hook) => {
+  predicateHook = clone(hook);
+  return new Promise(resolve => {
+    predicateValue = null;
+    return resolve(predicateValue);
+  });
+};
+
+const hookFcnSync = (hook) => {
+  hookFcnSyncCalls = +1;
+  hook.data.first = hook.data.first.toLowerCase();
+
+  return hook;
+};
+
+const hookFcnAsync = (hook) => new Promise(resolve => {
+  hookFcnAsyncCalls = +1;
+  hook.data.first = hook.data.first.toLowerCase();
+
+  resolve(hook);
+});
+
+const hookFcnCb = (hook, cb) => {
+  hookFcnCbCalls = +1;
+
+  cb(null, hook);
+};
+
+describe('unless - sync predicate, sync hook', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+  });
+
+  it('calls sync hook function if falsey non-function', () => {
+    hooks.unless(false, hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('does not call sync hook function if truthy non-function', () => {
+    const result = hooks.unless(true, hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      assert.fail(true, false, 'promise unexpectedly returned');
+    } else {
+      assert.deepEqual(result, hookBefore);
+      assert.equal(hookFcnSyncCalls, 0);
+      assert.deepEqual(hook, hookBefore);
+    }
+  });
+
+  it('calls sync hook function if sync predicate falsey', () => {
+    hooks.unless(() => false, hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('does not call sync hook function if sync predicate truthy', () => {
+    const result = hooks.unless(() => true, hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      assert.fail(true, false, 'promise unexpectedly returned');
+    } else {
+      assert.deepEqual(result, hookBefore);
+      assert.equal(hookFcnSyncCalls, 0);
+      assert.deepEqual(hook, hookBefore);
+    }
+  });
+});
+
+describe('unless - sync predicate, async hook', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+  });
+
+  it('calls async hook function if sync predicate falsey', (done) => {
+    const result = hooks.unless(false, hookFcnAsync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then((result1) => {
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+
+  it('does not call async hook function if sync predicate truthy', () => {
+    const result = hooks.unless(true, hookFcnAsync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      assert.fail(true, false, 'promise unexpectedly returned');
+    } else {
+      assert.deepEqual(result, hookBefore);
+      assert.equal(hookFcnAsyncCalls, 0);
+      assert.deepEqual(hook, hookBefore);
+    }
+  });
+
+  it('calls async hook function if sync predicate returns falsey', (done) => {
+    const result = hooks.unless(() => false, hookFcnAsync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then((result1) => {
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+});
+
+describe('unless - async predicate, sync hook', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+  });
+
+  it('calls sync hook function if aync predicate falsey', (done) => {
+    const result = hooks.unless(() => new Promise(resolve => resolve(false)), hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(result1, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+
+  it('does not call sync hook function if async predicate truthy', (done) => {
+    const result = hooks.unless(() => new Promise(resolve => resolve(true)), hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(result1, hookBefore);
+        assert.equal(hookFcnSyncCalls, 0);
+        assert.deepEqual(hook, hookBefore);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+});
+
+describe('unless - async predicate, async hook', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+  });
+
+  it('calls async hook function if aync predicate falsey', (done) => {
+    const result = hooks.unless(() => new Promise(resolve => resolve(false)), hookFcnAsync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.deepEqual(result1, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+      done();
+    }
+  });
+
+  it('does not call async hook function if async predicate truthy', (done) => {
+    const result = hooks.unless(() => new Promise(resolve => resolve(true)), hookFcnAsync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(result1, hookBefore);
+        assert.equal(hookFcnAsyncCalls, 0);
+        assert.deepEqual(hook, hookBefore);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+      done();
+    }
+  });
+});
+
+describe('unless - sync predicate', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+    predicateHook = null;
+    predicateOptions = null;
+  });
+
+  it('does not need to access hook', () => {
+    hooks.unless(() => false, hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('is passed hook as param', () => {
+    hooks.unless(predicateSync, hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(predicateHook, hookBefore);
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('a higher order predicate can pass more options', () => {
+    hooks.unless(predicateSync2({ z: 'z' }), hookFcnSync)(hook)
+      .then(hook => {
+        assert.deepEqual(predicateOptions, { z: 'z' });
+        assert.deepEqual(predicateHook, hookBefore);
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+});
+
+describe('unless - async predicate', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+    predicateHook = null;
+    predicateOptions = null;
+    predicateValue = null;
+  });
+
+  it('is passed hook as param', (done) => {
+    const result = hooks.unless(predicateAsync, hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(predicateHook, hookBefore);
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(result1, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+
+  it('is resolved', (done) => {
+    const result = hooks.unless(predicateAsyncFunny, hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(predicateHook, hookBefore);
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(result1, hookAfter);
+
+        assert.equal(predicateValue, null);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+
+  it('a higher order predicate can pass more options', (done) => {
+    const result = hooks.unless(predicateAsync2({ y: 'y' }), hookFcnSync)(hook);
+
+    if (result && typeof result.then === 'function') {
+      result.then(result1 => {
+        assert.deepEqual(predicateOptions, { y: 'y' });
+        assert.deepEqual(predicateHook, hookBefore);
+        assert.deepEqual(result1, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.deepEqual(result1, hookAfter);
+
+        done();
+      });
+    } else {
+      assert.fail(true, false, 'promise unexpectedly not returned');
+
+      done();
+    }
+  });
+});
+
+describe('unless - runs multiple hooks', () => {
+  beforeEach(() => {
+    hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
+    hookAfter = { type: 'before', method: 'create', data: { first: 'john', last: 'Doe' } };
+    hook = clone(hookBefore);
+    hookFcnSyncCalls = 0;
+    hookFcnAsyncCalls = 0;
+  });
+
+  it('runs successfully', (done) => {
+    hooks.unless(false, hookFcnSync, hookFcnAsync, hookFcnCb)(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+
+        done();
+      });
+  });
+});
+
+// Helpers
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
### Summary

Adding a utility hook that takes in a predicate function and a set of hooks. If the predicate function returns a falsey value the hooks are executed, otherwise they are not. Synonymous with `iff(isNot(fn), hook1, hook2, hook3)` except that the predicate does not need to be a function.

Usage is like so:

```js
unless(predicate, hook2, hook3)
````

### Other Information

Related to this discussion https://github.com/feathersjs/feathers-permissions/issues/4