### PR TITLE
Traverse and change hook.data .result .query or hook.anyObj

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "homepage": "https://github.com/feathers/feathers-hooks-common#readme",
   "dependencies": {
     "debug": "^2.2.0",
-    "feathers-errors": "^2.4.0"
+    "feathers-errors": "^2.4.0",
+    "traverse": "0.6.6"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -1,0 +1,119 @@
+if (!global._babelPolyfill) { require('babel-polyfill'); }
+
+import assert from 'assert';
+import hooks from '../src';
+
+describe('traverse', () => {
+  let hookBefore;
+  let hookBeforeArray;
+  let trimmer;
+  let hookAfter;
+  let hookAfterArray;
+
+  beforeEach(() => {
+    hookBefore = {
+      type: 'before',
+      method: 'create',
+      data: { a: ' a  b  ' },
+      params: { query: { b: '  b  b  ' } }
+    };
+
+    hookBeforeArray = {
+      type: 'before',
+      method: 'create',
+      data: [{ a: ' a  b  ' }, { c: ' c ' }],
+      params: { query: { b: '  b  b  ' }, something: { c: ' c', d: 'd ' } }
+    };
+
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      data: { q: 1 },
+      params: { query: { b: '  b  b  ' } },
+      result: { a: ' a  b  ' }
+    };
+
+    hookAfterArray = {
+      type: 'after',
+      method: 'create',
+      data: { q: 1 },
+      params: { query: { b: '  b  b  ' } },
+      result: [{ a: ' a  b  ' }, { c: ' c ' }]
+    };
+
+    trimmer = function (node) {
+      if (typeof node === 'string') {
+        this.update(node.trim());
+      }
+    };
+  });
+
+  it('transforms hook.data single item', () => {
+    const result = clone(hookBefore);
+    result.data = { a: 'a  b' };
+
+    hooks.traverse(trimmer)(hookBefore);
+
+    assert.deepEqual(hookBefore, result);
+  });
+
+  it('transforms hook.data array of items', () => {
+    const result = clone(hookBeforeArray);
+    result.data = [{ a: 'a  b' }, { c: 'c' }];
+
+    hooks.traverse(trimmer)(hookBeforeArray);
+
+    assert.deepEqual(hookBeforeArray, result);
+  });
+
+  it('transforms hook.result single item', () => {
+    const result = clone(hookAfter);
+    result.result = { a: 'a  b' };
+
+    hooks.traverse(trimmer)(hookAfter);
+
+    assert.deepEqual(hookAfter, result);
+  });
+
+  it('transforms hook.result array of items', () => {
+    const result = clone(hookAfterArray);
+    result.result = [{ a: 'a  b' }, { c: 'c' }];
+
+    hooks.traverse(trimmer)(hookAfterArray);
+
+    assert.deepEqual(hookAfterArray, result);
+  });
+
+  it('transforms hook.params.query', () => {
+    const result = clone(hookBefore);
+    result.params.query = { b: 'b  b' };
+
+    hooks.traverse(trimmer, hook => hook.params.query)(hookBefore);
+
+    assert.deepEqual(hookBefore, result);
+  });
+
+  it('transforms multiple objects within a hook', () => {
+    const result = clone(hookBeforeArray);
+    result.params = { query: { b: 'b  b' }, something: { c: 'c', d: 'd' } };
+
+    hooks.traverse(trimmer, hook => [hook.params.query, hook.params.something])(hookBeforeArray);
+
+    assert.deepEqual(hookBeforeArray, result);
+  });
+
+  it('transforms objects', () => {
+    const obj = { query: { b: 'b  b' }, something: { c: 'c', d: 'd' } };
+    const result = clone(obj);
+
+    hooks.traverse(trimmer, obj)(hookBeforeArray);
+
+    assert.deepEqual(obj, result);
+  });
+});
+
+// Helpers
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
- Issue #37 asks for hook to trim all strings
- BestBuy/api-playground has hook to convert all strings in .query that are "null" to null. Likely used with REST HTTP transports.
- This hook can do the above and much more.
- Hook uses substack/js-traverse which is reasonable in size.
- Can use this js-traverse's get/set methods in our get/setByDot utils instead of our own code.