### PR TITLE
Allowing populate include:{...} to act like include:[{...}]

### DIFF
--- a/src/hooks/populate.js
+++ b/src/hooks/populate.js
@@ -41,8 +41,8 @@ export const populate = (options, ...rest) => {
           throw new errors.BadRequest('Schema does not resolve to an object. (populate)');
         }
 
-        return !schema1.include || !Object.keys(schema1.include).length ? items
-          : populateItemArray(options1, hook, items, schema1.include, 0);
+        const include = [].concat(schema1.include || []);
+        return !include.length ? items : populateItemArray(options1, hook, items, include, 0);
       })
       .then(items => {
         replaceItems(hook, items);
@@ -70,10 +70,11 @@ function populateItem (options, hook, item, includeSchema, depth) {
 
   const elapsed = {};
   const startAtAllIncludes = process.hrtime();
+  const include = [].concat(includeSchema || []);
   item._include = [];
 
   return Promise.all(
-    includeSchema.map(childSchema => {
+    include.map(childSchema => {
       const startAtThisInclude = process.hrtime();
       return populateAddChild(options, hook, item, childSchema, depth)
         .then(result => {

--- a/test/hooks/populate/populate-1deep-1child.test.js
+++ b/test/hooks/populate/populate-1deep-1child.test.js
@@ -6,255 +6,243 @@ const { populate } = require('../../../src/hooks');
 
 const assert = chai.assert;
 
-describe('populate - include 1:1', () => {
-  let hookAfter;
-  let hookAfterArray;
+['array', 'obj'].forEach(type => {
+  describe(`populate - include 1:1 - ${type}`, () => {
+    let hookAfter;
+    let hookAfterArray;
 
-  let app;
-  let recommendation;
+    let app;
+    let recommendation;
 
-  beforeEach(() => {
-    app = configApp(['posts', 'recommendation']);
-    recommendation = clone(getInitDb('recommendation').store);
+    beforeEach(() => {
+      app = configApp(['posts', 'recommendation']);
+      recommendation = clone(getInitDb('recommendation').store);
 
-    hookAfter = {
-      type: 'after',
-      method: 'create',
-      params: { provider: 'rest' },
-      path: 'recommendations',
-      result: recommendation['1']
-    };
-    hookAfterArray = {
-      type: 'after',
-      method: 'create',
-      params: { provider: 'rest' },
-      path: 'recommendations',
-      result: [recommendation['1'], recommendation['2'], recommendation['3']]
-    };
-  });
+      hookAfter = {
+        type: 'after',
+        method: 'create',
+        params: { provider: 'rest' },
+        path: 'recommendations',
+        result: recommendation['1']
+      };
+      hookAfterArray = {
+        type: 'after',
+        method: 'create',
+        params: { provider: 'rest' },
+        path: 'recommendations',
+        result: [recommendation['1'], recommendation['2'], recommendation['3']]
+      };
+    });
 
-  describe('root is one item', () => {
-    it('saves in nameAs', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+    describe('root is one item', () => {
+      it('saves in nameAs', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             nameAs: 'post',
             parentField: 'postId', // we have no test for dot notation 'cause no such data
             childField: 'id'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema })(hook)
-        .then(hook1 => {
-          const expected = recommendationPosts('post');
-          assert.deepEqual(hook1.result, expected);
-        });
-    });
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('post');
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
 
-    it('saves in service as default', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('saves in service as default', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             parentField: 'postId',
             childField: 'id'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema })(hook)
-        .then(hook1 => {
-          const expected = recommendationPosts('posts');
-          assert.deepEqual(hook1.result, expected);
-        });
-    });
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
 
-    it('uses asArray', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('uses asArray', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             parentField: 'postId',
             childField: 'id',
             asArray: true
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema })(hook)
-        .then(hook1 => {
-          const expected = recommendationPosts('posts', true);
-          assert.deepEqual(hook1.result, expected);
-        });
-    });
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts', true);
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
 
-    it('query overridden by childField', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('query overridden by childField', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             parentField: 'postId',
             childField: 'id',
             query: { id: 'aaaaaa' }
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema })(hook)
-        .then(hook1 => {
-          const expected = recommendationPosts('posts');
-          assert.deepEqual(hook1.result, expected);
-        });
-    });
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
 
-    it('childField overridden by select', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('childField overridden by select', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             parentField: 'updatedAt',
             childField: 'id',
             select: (hook, parent) => ({ id: parent.postId })
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema })(hook)
-        .then(hook1 => {
-          const expected = recommendationPosts('posts');
-          assert.deepEqual(hook1.result, expected);
-        });
-    });
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
 
-    it('checks permissions', () => {
-      let spy = [];
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('checks permissions', () => {
+        let spy = [];
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const checkPermissions = (hook, service, permissions, depth) => {
-        spy.push({ service, permissions, depth });
-        return true;
-      };
+        const checkPermissions = (hook, service, permissions, depth) => {
+          spy.push({ service, permissions, depth });
+          return true;
+        };
 
-      const schema = {
-        permissions: 'for root',
-        include: [
-          {
+        const schema = {
+          permissions: 'for root',
+          include: makeInclude(type, {
             service: 'posts',
             nameAs: 'post',
             parentField: 'postId',
             childField: 'id',
             permissions: 'for posts'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema, checkPermissions })(hook)
-        .then(hook1 => {
-          let expected = recommendationPosts('post');
-          assert.deepEqual(hook1.result, expected);
+        return populate({ schema, checkPermissions })(hook)
+          .then(hook1 => {
+            let expected = recommendationPosts('post');
+            assert.deepEqual(hook1.result, expected);
 
-          expected = [
-            { service: 'recommendations', permissions: 'for root', depth: 0 },
-            { service: 'posts', permissions: 'for posts', depth: 1 }
-          ];
-          assert.deepEqual(spy, expected);
-        });
-    });
+            expected = [
+              { service: 'recommendations', permissions: 'for root', depth: 0 },
+              { service: 'posts', permissions: 'for posts', depth: 1 }
+            ];
+            assert.deepEqual(spy, expected);
+          });
+      });
 
-    it('throws on invalid permissions', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('throws on invalid permissions', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const checkPermissions = (hook, service, permissions, depth) => {
-        return depth === 0;
-      };
+        const checkPermissions = (hook, service, permissions, depth) => {
+          return depth === 0;
+        };
 
-      const schema = {
-        permissions: 'for root',
-        include: [
-          {
+        const schema = {
+          permissions: 'for root',
+          include: makeInclude(type, {
             service: 'posts',
             nameAs: 'post',
             parentField: 'postId',
             childField: 'id',
             permissions: 'for posts'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema, checkPermissions })(hook)
-        .then(() => { throw new Error('was not supposed to succeed'); })
-        .catch(err => { assert.notEqual(err, undefined); });
-    });
+        return populate({ schema, checkPermissions })(hook)
+          .then(() => { throw new Error('was not supposed to succeed'); })
+          .catch(err => { assert.notEqual(err, undefined); });
+      });
 
-    it('stores elapsed time', () => {
-      const hook = clone(hookAfter);
-      hook.app = app; // app is a func and wouldn't be cloned
+      it('stores elapsed time', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             nameAs: 'post',
             parentField: 'postId',
             childField: 'id'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema, profile: true })(hook)
-        .then(hook1 => {
-          const elapsed = hook1.result._elapsed;
-          assert.deepEqual(Object.keys(elapsed), ['post', 'total']);
-          assert.isAbove(elapsed.total, 1000);
-          assert.isAtLeast(elapsed.total, elapsed.post);
-        });
+        return populate({ schema, profile: true })(hook)
+          .then(hook1 => {
+            const elapsed = hook1.result._elapsed;
+            assert.deepEqual(Object.keys(elapsed), ['post', 'total']);
+            assert.isAbove(elapsed.total, 1000);
+            assert.isAtLeast(elapsed.total, elapsed.post);
+          });
+      });
     });
-  });
 
-  describe('root is item array', () => {
-    it('populates each item', () => {
-      const hook = clone(hookAfterArray);
-      hook.app = app; // app is a func and wouldn't be cloned
+    describe('root is item array', () => {
+      it('populates each item', () => {
+        const hook = clone(hookAfterArray);
+        hook.app = app; // app is a func and wouldn't be cloned
 
-      const schema = {
-        include: [
-          {
+        const schema = {
+          include: makeInclude(type, {
             service: 'posts',
             nameAs: 'post',
             parentField: 'postId',
             childField: 'id'
-          }
-        ]
-      };
+          })
+        };
 
-      return populate({ schema, profile: true })(hook)
-        .then(hook1 => {
-          assert.equal(hook1.result.length, 3);
-        });
+        return populate({ schema, profile: true })(hook)
+          .then(hook1 => {
+            assert.equal(hook1.result.length, 3);
+          });
+      });
     });
   });
 });
 
 // Helpers
+
+function makeInclude (type, obj) {
+  return type === 'obj' ? obj : [obj];
+}
 
 function recommendationPosts (nameAs, asArray, recommendation, posts) {
   recommendation = recommendation || clone(getInitDb('recommendation').store['1']);

--- a/test/hooks/populate/populate-relations.test.js
+++ b/test/hooks/populate/populate-relations.test.js
@@ -4,37 +4,37 @@ const configApp = require('../../helpers/configApp');
 const getInitDb = require('../../helpers/getInitDb');
 const { populate } = require('../../../src/hooks');
 
-describe('populate - 1:1 & 1:m & m:1', () => {
-  let hookAfter;
-  let hookAfterArray;
-  let schema;
+['array', 'obj'].forEach(type => {
+  describe(`populate - 1:1 & 1:m & m:1 - ${type}`, () => {
+    let hookAfter;
+    let hookAfterArray;
+    let schema;
 
-  let app;
-  let recommendation;
+    let app;
+    let recommendation;
 
-  beforeEach(() => {
-    app = configApp(['recommendation', 'posts', 'users', 'comments']);
-    recommendation = clone(getInitDb('recommendation').store);
+    beforeEach(() => {
+      app = configApp(['recommendation', 'posts', 'users', 'comments']);
+      recommendation = clone(getInitDb('recommendation').store);
 
-    hookAfter = {
-      type: 'after',
-      method: 'create',
-      params: { provider: 'rest' },
-      path: 'recommendations',
-      result: recommendation['1']
-    };
-    hookAfterArray = {
-      type: 'after',
-      method: 'create',
-      params: { provider: 'rest' },
-      path: 'recommendations',
-      result: [recommendation['1'], recommendation['2'], recommendation['3']]
-    };
+      hookAfter = {
+        type: 'after',
+        method: 'create',
+        params: { provider: 'rest' },
+        path: 'recommendations',
+        result: recommendation['1']
+      };
+      hookAfterArray = {
+        type: 'after',
+        method: 'create',
+        params: { provider: 'rest' },
+        path: 'recommendations',
+        result: [recommendation['1'], recommendation['2'], recommendation['3']]
+      };
 
-    schema = {
-      permissions: '',
-      include: [
-        {
+      schema = {
+        permissions: '',
+        include: makeInclude(type, {
           service: 'posts',
           nameAs: 'post',
           parentField: 'postId',
@@ -69,141 +69,18 @@ describe('populate - 1:1 & 1:m & m:1', () => {
               childField: 'id'
             }
           ]
-        }
-      ]
-    };
-  });
+        })
+      };
+    });
 
-  it('for one item', () => {
-    const hook = clone(hookAfter);
-    hook.app = app; // app is a func and wouldn't be cloned
+    it('for one item', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
 
-    return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
-      .then(hook1 => {
-        assert.deepEqual(hook1.result,
-          { userId: 'as61389dadhga62343hads6712',
-            postId: 1,
-            updatedAt: 1480793101475,
-            _include: [ 'post' ],
-            _elapsed: { post: 1, total: 1 },
-            post:
-            { id: 1,
-              title: 'Post 1',
-              content: 'Lorem ipsum dolor sit amet 4',
-              author: 'as61389dadhga62343hads6712',
-              readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
-              createdAt: 1480793101559,
-              _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
-              _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
-              authorInfo:
-              { id: 'as61389dadhga62343hads6712',
-                name: 'Author 1',
-                email: 'author1@posties.com',
-                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                age: 55 },
-              commentsInfo:
-                [ { title: 'Comment 1',
-                  content: 'Lorem ipsum dolor sit amet 1',
-                  postId: 1 },
-                  { title: 'Comment 3',
-                    content: 'Lorem ipsum dolor sit amet 3',
-                    postId: 1 } ],
-              readersInfo:
-                [ { id: 'as61389dadhga62343hads6712',
-                  name: 'Author 1',
-                  email: 'author1@posties.com',
-                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                  age: 55 },
-                  { id: '167asdf3689348sdad7312131s',
-                    name: 'Author 2',
-                    email: 'author2@posties.com',
-                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                    age: 16 } ] } }
-        );
-      });
-  });
-
-  it('for an item array', () => {
-    const hook = clone(hookAfterArray);
-    hook.app = app; // app is a func and wouldn't be cloned
-
-    return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
-      .then(hook1 => {
-        assert.deepEqual(hook1.result,
-          [ { userId: 'as61389dadhga62343hads6712',
-            postId: 1,
-            updatedAt: 1480793101475,
-            _include: [ 'post' ],
-            _elapsed: { post: 1, total: 1 },
-            post:
-            { id: 1,
-              title: 'Post 1',
-              content: 'Lorem ipsum dolor sit amet 4',
-              author: 'as61389dadhga62343hads6712',
-              readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
-              createdAt: 1480793101559,
-              _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
-              _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
-              authorInfo:
-              { id: 'as61389dadhga62343hads6712',
-                name: 'Author 1',
-                email: 'author1@posties.com',
-                password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                age: 55 },
-              commentsInfo:
-                [ { title: 'Comment 1',
-                  content: 'Lorem ipsum dolor sit amet 1',
-                  postId: 1 },
-                  { title: 'Comment 3',
-                    content: 'Lorem ipsum dolor sit amet 3',
-                    postId: 1 } ],
-              readersInfo:
-                [ { id: 'as61389dadhga62343hads6712',
-                  name: 'Author 1',
-                  email: 'author1@posties.com',
-                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                  age: 55 },
-                  { id: '167asdf3689348sdad7312131s',
-                    name: 'Author 2',
-                    email: 'author2@posties.com',
-                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                    age: 16 } ] } },
+      return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
+        .then(hook1 => {
+          assert.deepEqual(hook1.result,
             { userId: 'as61389dadhga62343hads6712',
-              postId: 2,
-              updatedAt: 1480793101475,
-              _include: [ 'post' ],
-              _elapsed: { post: 1, total: 1 },
-              post:
-              { id: 2,
-                title: 'Post 2',
-                content: 'Lorem ipsum dolor sit amet 5',
-                author: '167asdf3689348sdad7312131s',
-                readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
-                createdAt: 1480793101559,
-                _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
-                _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
-                authorInfo:
-                { id: '167asdf3689348sdad7312131s',
-                  name: 'Author 2',
-                  email: 'author2@posties.com',
-                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                  age: 16 },
-                commentsInfo:
-                  [ { title: 'Comment 2',
-                    content: 'Lorem ipsum dolor sit amet 2',
-                    postId: 2 } ],
-                readersInfo:
-                  [ { id: 'as61389dadhga62343hads6712',
-                    name: 'Author 1',
-                    email: 'author1@posties.com',
-                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                    age: 55 },
-                    { id: '167asdf3689348sdad7312131s',
-                      name: 'Author 2',
-                      email: 'author2@posties.com',
-                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                      age: 16 } ] } },
-            { userId: '167asdf3689348sdad7312131s',
               postId: 1,
               updatedAt: 1480793101475,
               _include: [ 'post' ],
@@ -240,13 +117,140 @@ describe('populate - 1:1 & 1:m & m:1', () => {
                       name: 'Author 2',
                       email: 'author2@posties.com',
                       password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
-                      age: 16 } ] } } ]
-        );
-      });
+                      age: 16 } ] } }
+          );
+        });
+    });
+
+    it('for an item array', () => {
+      const hook = clone(hookAfterArray);
+      hook.app = app; // app is a func and wouldn't be cloned
+
+      return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
+        .then(hook1 => {
+          assert.deepEqual(hook1.result,
+            [ { userId: 'as61389dadhga62343hads6712',
+              postId: 1,
+              updatedAt: 1480793101475,
+              _include: [ 'post' ],
+              _elapsed: { post: 1, total: 1 },
+              post:
+              { id: 1,
+                title: 'Post 1',
+                content: 'Lorem ipsum dolor sit amet 4',
+                author: 'as61389dadhga62343hads6712',
+                readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+                createdAt: 1480793101559,
+                _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+                _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+                authorInfo:
+                { id: 'as61389dadhga62343hads6712',
+                  name: 'Author 1',
+                  email: 'author1@posties.com',
+                  password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                  age: 55 },
+                commentsInfo:
+                  [ { title: 'Comment 1',
+                    content: 'Lorem ipsum dolor sit amet 1',
+                    postId: 1 },
+                    { title: 'Comment 3',
+                      content: 'Lorem ipsum dolor sit amet 3',
+                      postId: 1 } ],
+                readersInfo:
+                  [ { id: 'as61389dadhga62343hads6712',
+                    name: 'Author 1',
+                    email: 'author1@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 55 },
+                    { id: '167asdf3689348sdad7312131s',
+                      name: 'Author 2',
+                      email: 'author2@posties.com',
+                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                      age: 16 } ] } },
+              { userId: 'as61389dadhga62343hads6712',
+                postId: 2,
+                updatedAt: 1480793101475,
+                _include: [ 'post' ],
+                _elapsed: { post: 1, total: 1 },
+                post:
+                { id: 2,
+                  title: 'Post 2',
+                  content: 'Lorem ipsum dolor sit amet 5',
+                  author: '167asdf3689348sdad7312131s',
+                  readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+                  createdAt: 1480793101559,
+                  _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+                  _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+                  authorInfo:
+                  { id: '167asdf3689348sdad7312131s',
+                    name: 'Author 2',
+                    email: 'author2@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 16 },
+                  commentsInfo:
+                    [ { title: 'Comment 2',
+                      content: 'Lorem ipsum dolor sit amet 2',
+                      postId: 2 } ],
+                  readersInfo:
+                    [ { id: 'as61389dadhga62343hads6712',
+                      name: 'Author 1',
+                      email: 'author1@posties.com',
+                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                      age: 55 },
+                      { id: '167asdf3689348sdad7312131s',
+                        name: 'Author 2',
+                        email: 'author2@posties.com',
+                        password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                        age: 16 } ] } },
+              { userId: '167asdf3689348sdad7312131s',
+                postId: 1,
+                updatedAt: 1480793101475,
+                _include: [ 'post' ],
+                _elapsed: { post: 1, total: 1 },
+                post:
+                { id: 1,
+                  title: 'Post 1',
+                  content: 'Lorem ipsum dolor sit amet 4',
+                  author: 'as61389dadhga62343hads6712',
+                  readers: [ 'as61389dadhga62343hads6712', '167asdf3689348sdad7312131s' ],
+                  createdAt: 1480793101559,
+                  _include: [ 'authorInfo', 'commentsInfo', 'readersInfo' ],
+                  _elapsed: { authorInfo: 2, commentsInfo: 2, readersInfo: 2, total: 2 },
+                  authorInfo:
+                  { id: 'as61389dadhga62343hads6712',
+                    name: 'Author 1',
+                    email: 'author1@posties.com',
+                    password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                    age: 55 },
+                  commentsInfo:
+                    [ { title: 'Comment 1',
+                      content: 'Lorem ipsum dolor sit amet 1',
+                      postId: 1 },
+                      { title: 'Comment 3',
+                        content: 'Lorem ipsum dolor sit amet 3',
+                        postId: 1 } ],
+                  readersInfo:
+                    [ { id: 'as61389dadhga62343hads6712',
+                      name: 'Author 1',
+                      email: 'author1@posties.com',
+                      password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                      age: 55 },
+                      { id: '167asdf3689348sdad7312131s',
+                        name: 'Author 2',
+                        email: 'author2@posties.com',
+                        password: '2347wjkadhad8y7t2eeiudhd98eu2rygr',
+                        age: 16 } ] } } ]
+          );
+        });
+    });
   });
 });
 
 // Helpers
+
+function makeInclude (type, obj) {
+  return type === 'obj' ? obj : [obj];
+}
 
 function clone (obj) {
   return JSON.parse(JSON.stringify(obj));


### PR DESCRIPTION
Don't require a single join to have to be specified as a 1 element array.

- Modified just the new module as the old will be removed shortly
- Relavent tests now run using both syntax

Recasting of PR #76 which has gotten dated and been closed.