### PR TITLE
Populate 3

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -111,6 +111,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
       childField: 'postId',
       query: { $limit: 5, $select: ['title', 'content', 'postId'], $sort: { createdAt: -1 } },
       select: (hook, parent, depth) => ({ something: { $exists: false }}),
+      paginate: false,
       include: [ ... ],
     }
   */
@@ -155,7 +156,9 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         throw new errors.BadRequest(`Service ${childSchema.service} is not configured. (populate)`);
       }
 
-      const params = Object.assign({}, hook.params, { query, _populate: 'skip' });
+      const paginate = 'paginate' in childSchema ? childSchema.paginate : false;
+
+      const params = Object.assign({}, hook.params, { query, paginate, _populate: 'skip' });
       return serviceHandle.find(params);
     })
     .then(result => {

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -11,7 +11,7 @@ export default function (options, ...rest) {
     return legacyPopulate(options, ...rest);
   }
 
-  return hook => {
+  return function (hook) {
     const optionsDefault = {
       schema: {},
       checkPermissions: () => true,
@@ -155,7 +155,8 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         throw new errors.BadRequest(`Service ${childSchema.service} is not configured. (populate)`);
       }
 
-      return serviceHandle.find({ query, _populate: 'skip' });
+      const params = Object.assign({}, hook.params, { query, _populate: 'skip' });
+      return serviceHandle.find(params);
     })
     .then(result => {
       result = result.data || result;

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -156,9 +156,12 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         throw new errors.BadRequest(`Service ${childSchema.service} is not configured. (populate)`);
       }
 
-      const paginate = 'paginate' in childSchema ? childSchema.paginate : false;
+      let paginate = { paginate: false };
+      const paginateOption = childSchema.paginate;
+      if (paginateOption === true) { paginate = null; }
+      if (typeof paginateOption === 'number') { paginate = { paginate: { default: paginateOption } }; }
 
-      const params = Object.assign({}, hook.params, { query, paginate, _populate: 'skip' });
+      const params = Object.assign({}, hook.params, paginate, { query, _populate: 'skip' });
       return serviceHandle.find(params);
     })
     .then(result => {

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -7,6 +7,7 @@ import legacyPopulate from './legacy-populate';
 import replaceItems from './replace-items';
 
 export default function (options, ...rest) {
+  // options.schema is like { service: '...', permissions: '...', include: [ ... ] }
   if (typeof options === 'string') {
     return legacyPopulate(options, ...rest);
   }
@@ -31,9 +32,14 @@ export default function (options, ...rest) {
         const { schema, checkPermissions } = options1;
         const schema1 = typeof schema === 'function' ? schema(hook, options1) : schema;
         const permissions = schema1.permissions || null;
+        const baseService = schema1.service;
 
         if (typeof checkPermissions !== 'function') {
           throw new errors.BadRequest('Permissions param is not a function. (populate)');
+        }
+
+        if (baseService && baseService !== hook.path) {
+          throw new errors.BadRequest(`Schema is for ${baseService} not ${hook.path}. (populate)`);
         }
 
         if (permissions && !checkPermissions(hook, hook.path, permissions, 0)) {

--- a/test/services/populate-misc.test.js
+++ b/test/services/populate-misc.test.js
@@ -1,0 +1,101 @@
+
+const assert = require('chai').assert;
+const feathers = require('feathers');
+const memory = require('feathers-memory');
+const feathersHooks = require('feathers-hooks');
+const { populate } = require('../../src/services');
+
+const userId = 6;
+const userInit = {
+  '0': { name: 'Jane Doe', key: 'a', id: 0 },
+  '1': { name: 'Jack Doe', key: 'a', id: 1 },
+  '2': { name: 'Jack Doe', key: 'a', id: 2, deleted: true },
+  '3': { name: 'Rick Doe', key: 'b', id: 3 },
+  '4': { name: 'Dick Doe', key: 'b', id: 4 },
+  '5': { name: 'Dick Doe', key: 'b', id: 5, deleted: true }
+};
+const teamId = 2;
+const teamInit = {
+  '0': { team: 'Does', memberIds: [0, 1, 2], id: 0 },
+  '1': { team: 'Dragons', memberIds: [3, 4, 5], id: 1 }
+};
+
+const schema = {
+  include: [{
+    service: 'users',
+    nameAs: 'members',
+    parentField: 'memberIds',
+    childField: 'id'
+  }]
+};
+
+let userHookFlag1;
+
+function services () {
+  const app = this;
+  app.configure(user);
+  app.configure(team);
+}
+
+function user () {
+  const app = this;
+
+  app.use('/users', memory({
+    store: clone(userInit),
+    startId: userId
+  }));
+
+  app.service('users').before({
+    all: [
+      hook => { userHookFlag1 = hook.params.userHookFlag1; }
+    ]
+  });
+}
+
+function team () {
+  const app = this;
+
+  app.use('/teams', memory({
+    store: clone(teamInit),
+    startId: teamId
+  }));
+
+  app.service('teams').after({
+    all: [populate({ schema })]
+  });
+}
+
+describe('populate - hook.params passed to includes', () => {
+  let app;
+  let teams;
+
+  beforeEach(() => {
+    app = feathers()
+      .configure(feathersHooks())
+      .configure(services);
+    teams = app.service('teams');
+    userHookFlag1 = null;
+  });
+
+  it('hook.params passed to includes', () => {
+    return teams.find({ query: { id: 0 }, userHookFlag1: 'userHookFlag1' })
+      .then(result => {
+        assert.equal(userHookFlag1, 'userHookFlag1');
+        assert.deepEqual(result, [{
+          team: 'Does',
+          memberIds: [ 0, 1, 2 ],
+          id: 0,
+          _include: [ 'members' ],
+          members: [
+            { name: 'Jane Doe', key: 'a', id: 0 },
+            { name: 'Jack Doe', key: 'a', id: 1 },
+            { name: 'Jack Doe', key: 'a', id: 2, deleted: true }
+          ]}
+        ]);
+      });
+  });
+});
+
+function clone (obj) {
+  return JSON.parse(JSON.stringify(obj));
+}

--- a/test/services/populate-misc.test.js
+++ b/test/services/populate-misc.test.js
@@ -41,17 +41,6 @@ const resultDefault = [{
   ]}
 ];
 
-const resultPaginated = [{
-  team: 'Does',
-  memberIds: [ 0, 1, 2 ],
-  id: 0,
-  _include: [ 'members' ],
-  members: [
-    { name: 'Jane Doe', key: 'a', id: 0 },
-    { name: 'Jack Doe', key: 'a', id: 1 }
-  ]}
-];
-
 const schemaFalse = {
   include: [{
     service: 'users',
@@ -68,9 +57,38 @@ const schemaTrue = {
     nameAs: 'members',
     parentField: 'memberIds',
     childField: 'id',
-    paginate: { default: 2 }
+    paginate: true
   }]
 };
+
+const resultTrue = [{
+  team: 'Does',
+  memberIds: [ 0, 1, 2 ],
+  id: 0,
+  _include: [ 'members' ],
+  members: [
+    { name: 'Jane Doe', key: 'a', id: 0 },
+    { name: 'Jack Doe', key: 'a', id: 1 }
+  ]}
+];
+
+const schema1 = {
+  include: [{
+    service: 'users',
+    nameAs: 'members',
+    parentField: 'memberIds',
+    childField: 'id',
+    paginate: 1
+  }]
+};
+
+const result1 = [{
+  team: 'Does',
+  memberIds: [ 0, 1, 2 ],
+  id: 0,
+  _include: [ 'members' ],
+  members: { name: 'Jane Doe', key: 'a', id: 0 }
+}];
 
 let whichSchema;
 let userHookFlag1;
@@ -112,7 +130,8 @@ function team () {
     all: [
       iff(hook => whichSchema === 'schemaDefault', populate({ schema: schemaDefault })),
       iff(hook => whichSchema === 'schemaFalse', populate({ schema: schemaFalse })),
-      iff(hook => whichSchema === 'schemaTrue', populate({ schema: schemaTrue }))
+      iff(hook => whichSchema === 'schemaTrue', populate({ schema: schemaTrue })),
+      iff(hook => whichSchema === 'schema1', populate({ schema: schema1 }))
     ]
   });
 }
@@ -154,11 +173,19 @@ describe('populate - hook.params passed to includes', () => {
       });
   });
 
-  it('does pagination when paginate:true', () => {
+  it('uses configuration when paginate:true', () => {
     whichSchema = 'schemaTrue';
     return teams.find({ query: { id: 0 } })
       .then(result => {
-        assert.deepEqual(result, resultPaginated);
+        assert.deepEqual(result, resultTrue);
+      });
+  });
+
+  it('can specify number of results to return', () => {
+    whichSchema = 'schema1';
+    return teams.find({ query: { id: 0 } })
+      .then(result => {
+        assert.deepEqual(result, result1);
       });
   });
 });

--- a/test/services/populate-misc.test.js
+++ b/test/services/populate-misc.test.js
@@ -41,6 +41,26 @@ const resultDefault = [{
   ]}
 ];
 
+const schemaDefaultTeams = {
+  service: 'teams',
+  include: [{
+    service: 'users',
+    nameAs: 'members',
+    parentField: 'memberIds',
+    childField: 'id'
+  }]
+};
+
+const schemaDefaultXteams = {
+  service: 'xteams',
+  include: [{
+    service: 'users',
+    nameAs: 'members',
+    parentField: 'memberIds',
+    childField: 'id'
+  }]
+};
+
 const schemaFalse = {
   include: [{
     service: 'users',
@@ -131,7 +151,9 @@ function team () {
       iff(hook => whichSchema === 'schemaDefault', populate({ schema: schemaDefault })),
       iff(hook => whichSchema === 'schemaFalse', populate({ schema: schemaFalse })),
       iff(hook => whichSchema === 'schemaTrue', populate({ schema: schemaTrue })),
-      iff(hook => whichSchema === 'schema1', populate({ schema: schema1 }))
+      iff(hook => whichSchema === 'schema1', populate({ schema: schema1 })),
+      iff(hook => whichSchema === 'schemaDefaultTeams', populate({ schema: schemaDefaultTeams })),
+      iff(hook => whichSchema === 'schemaDefaultXteams', populate({ schema: schemaDefaultXteams }))
     ]
   });
 }
@@ -186,6 +208,25 @@ describe('populate - hook.params passed to includes', () => {
     return teams.find({ query: { id: 0 } })
       .then(result => {
         assert.deepEqual(result, result1);
+      });
+  });
+
+  it('passes on correct base service', () => {
+    whichSchema = 'schemaDefaultTeams';
+    return teams.find({ query: { id: 0 } })
+      .then(result => {
+        assert.deepEqual(result, resultDefault);
+      });
+  });
+
+  it('throws on incorrect base service', () => {
+    whichSchema = 'schemaDefaultXteams';
+    return teams.find({ query: { id: 0 } })
+      .then(() => {
+        assert.fail(true, false, 'unexpected succeeded');
+      })
+      .catch(err => {
+        assert.equal(err.className, 'bad-request');
       });
   });
 });


### PR DESCRIPTION
Adding some enhancements to the populate hook. 2 of the 3 changes address issues people have raised.

One issue raised was that if the populate hook is on a service being called with a hook.params.provider, the calls for joining child services did not have a provider.

I checked other code, including the legacy populate hook with https://github.com/feathersjs/feathers-hooks-common/blob/master/src/services/legacy-populate.js#L36

They pass the parent's hook.param when calling the child. That certainly passes hook.params.provider to the child. I'm not yet familar enough to be certain that everything else that's passed along can't cause a problem. For example, what if the base service call included something with `.Model`?

So I'd like @daffl to review the first commit.