### PR TITLE
Deprecated setByDot usage for deleting props. Converted hooks to deleteByDot

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This feature has been removed.
 Deprecated:
 - The legacy populate hook -- with signtaure (string, ...) --
 will be removed next version. Use the new `populate` hook.
+- Use `deleteByDot` rather than `setByDot(obj, path, value, true)`.
 - The `delete` hook should be used instead of `remove`.
 You will need to wrap `delete` it in an conditional if you want it to work like `remove` does.
 - The `stop` hook may be used instead of `disable`.

--- a/src/common/_remove.js
+++ b/src/common/_remove.js
@@ -1,11 +1,11 @@
 
-import setByDot from './set-by-dot';
+import deleteByDot from './delete-by-dot';
 import _transformItems from './_transform-items';
 
 export default function (items /* modified */, fieldNames) {
   _transformItems(items, fieldNames, (item, fieldName, value) => {
     if (value !== undefined) {
-      setByDot(item, fieldName, undefined, true);
+      deleteByDot(item, fieldName);
     }
   });
 }

--- a/src/common/delete-by-dot.js
+++ b/src/common/delete-by-dot.js
@@ -7,7 +7,6 @@ export default function (obj, path) {
 
   for (let i = 0; i < nonLeafLen; i++) {
     let part = parts[i];
-    console.log(path, part, part in obj);
     if (!(part in obj)) { return; }
 
     obj = obj[part];

--- a/src/common/set-by-dot.js
+++ b/src/common/set-by-dot.js
@@ -1,5 +1,9 @@
 
 export default function (obj, path, value, ifDelete) {
+  if (ifDelete) {
+    console.log('DEPRECATED. Use deleteByDot instead of setByDot(obj,path,value,true). (setByDot)');
+  }
+
   if (path.indexOf('.') === -1) {
     obj[path] = value;
 

--- a/src/services/serialize.js
+++ b/src/services/serialize.js
@@ -3,6 +3,7 @@ import getByDot from '../common/get-by-dot';
 import getItems from './get-items';
 import replaceItems from './replace-items';
 import setByDot from '../common/set-by-dot';
+import deleteByDot from '../common/delete-by-dot';
 
 export default function (schema) {
   return hook => {
@@ -31,7 +32,10 @@ export default function (schema) {
       if (only) {
         const newItem = {};
         only.concat('_include', '_elapsed', item._include || []).forEach(key => {
-          setByDot(newItem, key, getByDot(item, key), true);
+          let value = getByDot(item, key);
+          if (value !== undefined) {
+            setByDot(newItem, key, value);
+          }
         });
         item = newItem;
       }
@@ -40,7 +44,7 @@ export default function (schema) {
       exclude = typeof exclude === 'string' ? [exclude] : exclude;
       if (exclude) {
         exclude.forEach(key => {
-          setByDot(item, key, undefined, true);
+          deleteByDot(item, key);
         });
       }
 


### PR DESCRIPTION
- setByDot can delete props. Its not clean in edge cases.
- Repo converted from using setByDot for this to using deleteByDot.
- Deprecated msg is logged when setByDot is used for deleting props.
- We can now implement dot notation for populate's nameAs as deleteByDot
was needed for dePopulate.