### PR TITLE
Added dot notation support for nameAs option in populate & dePopulate hooks

### DIFF
--- a/src/services/de-populate.js
+++ b/src/services/de-populate.js
@@ -1,6 +1,7 @@
 
 import getItems from './get-items';
 import replaceItems from './replace-items';
+import deleteByDot from '../common/delete-by-dot';
 
 export default function () {
   return hook => {
@@ -19,7 +20,7 @@ export default function () {
 
 function removeProps (name, item) {
   if (name in item) {
-    item[name].forEach(key => { delete item[key]; });
+    item[name].forEach(key => { deleteByDot(item, key); });
     delete item[name];
   }
 }

--- a/test/services/de-populate.test.js
+++ b/test/services/de-populate.test.js
@@ -1,8 +1,8 @@
 
 const assert = require('assert');
-const { dePopulate } = require('../../src/services');
+const { dePopulate } = require('../../src/services/index');
 
-describe('services dePopulate', () => {
+describe('services dePopulate - not dot notation', () => {
   let hookAfter;
   let hookBeforeArray;
   let hookBefore;
@@ -128,6 +128,151 @@ describe('services dePopulate', () => {
           userId: 'as61389dadhga62343hads6712',
           postId: 2,
           updatedAt: 1480793101475
+        },
+        {
+          userId: '167asdf3689348sdad7312131s',
+          postId: 1,
+          updatedAt: 1480793101475
+        }
+      ]
+    );
+  });
+});
+
+describe('services dePopulate - dot notation', () => {
+  let hookAfter;
+  let hookBeforeArray;
+  let hookBefore;
+
+  beforeEach(() => {
+    hookAfter = {
+      type: 'after',
+      method: 'create',
+      params: {provider: 'rest'},
+      result: {
+        userId: 'as61389dadhga62343hads6712',
+        postId: 1,
+        updatedAt: 1480793101475,
+        _include: ['post.a.b', 'x'],
+        _elapsed: { post: 16051500, total: 20707798, x: 1 },
+        _computed: ['a1', 'a1'],
+        a1: 1,
+        post: { a: { b: {
+          id: 1,
+          title: 'Post 1',
+          content: 'Lorem ipsum dolor sit amet 4',
+          author: 'as61389dadhga62343hads6712',
+          readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+          createdAt: 1480793101559
+        }}}
+      }
+    };
+    hookBefore = {
+      type: 'before',
+      method: 'update',
+      params: {provider: 'rest'},
+      data: {
+        userId: 'as61389dadhga62343hads6712',
+        postId: 1,
+        updatedAt: 1480793101475
+      }
+    };
+    hookBeforeArray = {
+      type: 'before',
+      method: 'patch',
+      params: { provider: 'rest' },
+      data: [
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 1,
+          updatedAt: 1480793101475,
+          _include: ['post.a'],
+          _elapsed: {post: 3456238, total: 3642135},
+          post: {
+            a: {
+              id: 1,
+              title: 'Post 1',
+              content: 'Lorem ipsum dolor sit amet 4',
+              author: 'as61389dadhga62343hads6712',
+              readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+              createdAt: 1480793101559
+            }
+          }
+        },
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 2,
+          updatedAt: 1480793101475,
+          _include: ['post.a', 'x', 'post.b.c', 'comments'],
+          _elapsed: {post: 3457496, total: 3878535},
+          comments: {},
+          post: {
+            a: {
+              id: 2,
+              title: 'Post 2',
+              content: 'Lorem ipsum dolor sit amet 5',
+              author: '167asdf3689348sdad7312131s',
+              readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+              createdAt: 1480793101559
+            }
+          }
+        },
+        {
+          userId: '167asdf3689348sdad7312131s',
+          postId: 1,
+          updatedAt: 1480793101475,
+          _include: ['post'],
+          _elapsed: {post: 3446912, total: 3857237},
+          post: {
+            id: 1,
+            title: 'Post 1',
+            content: 'Lorem ipsum dolor sit amet 4',
+            author: 'as61389dadhga62343hads6712',
+            readers: ['as61389dadhga62343hads6712', '167asdf3689348sdad7312131s'],
+            createdAt: 1480793101559
+          }
+        }
+      ]
+    };
+  });
+
+  it('one item, after hook, missing props', () => {
+    const hook = clone(hookAfter);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.result, {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475,
+      post: { a: {} }
+    });
+  });
+
+  it('one item, before hook, not populated', () => {
+    const hook = clone(hookBefore);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.data, {
+      userId: 'as61389dadhga62343hads6712',
+      postId: 1,
+      updatedAt: 1480793101475
+    });
+  });
+
+  it('item array, before hook', () => {
+    const hook = clone(hookBeforeArray);
+    const deHook = dePopulate()(hook);
+    assert.deepEqual(deHook.data,
+      [
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 1,
+          updatedAt: 1480793101475,
+          post: {}
+        },
+        {
+          userId: 'as61389dadhga62343hads6712',
+          postId: 2,
+          updatedAt: 1480793101475,
+          post: {}
         },
         {
           userId: '167asdf3689348sdad7312131s',

--- a/test/services/populate-basics.test.js
+++ b/test/services/populate-basics.test.js
@@ -1,8 +1,8 @@
 
 const assert = require('assert');
-const { populate } = require('../../src/services');
+const { populate } = require('../../src/services/index');
 
-describe('populate - finds items in hook', () => {
+describe('services populate - finds items in hook', () => {
   let hookAfter;
   let hookAfterArray;
   let hookFindPaginate;

--- a/test/services/populate-misc.test.js
+++ b/test/services/populate-misc.test.js
@@ -158,7 +158,7 @@ function team () {
   });
 }
 
-describe('populate - hook.params passed to includes', () => {
+describe('services populate - hook.params passed to includes', () => {
   let app;
   let teams;
 

--- a/test/services/populate-relations.test.js
+++ b/test/services/populate-relations.test.js
@@ -2,10 +2,10 @@
 const assert = require('assert');
 const configApp = require('../helpers/config-app');
 const getInitDb = require('../helpers/get-init-db');
-const { populate } = require('../../src/services');
+const { populate } = require('../../src/services/index');
 
 ['array', 'obj'].forEach(type => {
-  describe(`populate - 1:1 & 1:m & m:1 - ${type}`, () => {
+  describe(`services populate - 1:1 & 1:m & m:1 - ${type}`, () => {
     let hookAfter;
     let hookAfterArray;
     let schema;

--- a/test/services/populate-scaffolding.test.js
+++ b/test/services/populate-scaffolding.test.js
@@ -2,7 +2,7 @@
 const assert = require('assert');
 const configApp = require('../helpers/config-app');
 
-describe('populate - test scaffolding', () => {
+describe('services populate - test scaffolding', () => {
   it('can reinitialize database', done => {
     const app = configApp(['users', 'comments', 'posts', 'recommendation']);
     const users = app.service('users');


### PR DESCRIPTION
- { _include: ['post.a','post.b'], post: { a:[...], b:{...} }} will depopulate to { post: {} }.
- There is no reasonable way to determine it that post:{} should be deleted.
- The dev needs a custom hook to do that, perhaps wrapping dePopulate.