### PR TITLE
Prepare for 3.0.0 prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-hooks-common",
-  "version": "2.0.3",
+  "version": "3.0.0-pre.0",
   "description": "Useful hooks for use with Feathersjs services.",
   "main": "lib/",
   "directories": {
@@ -9,7 +9,7 @@
   "scripts": {
     "prepublish": "npm run compile",
     "publish": "git push origin --tags && npm run changelog && git push origin",
-    "release:prerelease": "npm version prerelease && npm publish",
+    "release:prerelease": "npm version prerelease && npm publish --tag pre",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",


### PR DESCRIPTION
So that we can just run `npm run release:pre`