### PR TITLE
Avoided side-effect of client

### DIFF
--- a/src/services/client.js
+++ b/src/services/client.js
@@ -1,7 +1,7 @@
 
 export default function (...whitelist) {
   whitelist = typeof whitelist === 'string' ? [whitelist] : whitelist;
-  
+
   return hook => {
     const params = hook.params;
 
@@ -14,7 +14,7 @@ export default function (...whitelist) {
         }
       });
 
-      params.query = JSON.parse(JSON.stringify(params.query));
+      params.query = Object.assign({}, params.query);
       delete params.query.$client;
     }
 

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -1,7 +1,5 @@
 
 export default function (...whitelist) {
-  whitelist = typeof whitelist === 'string' ? [whitelist] : whitelist;
-
   return hook => {
     const params = hook.params;
 

--- a/src/services/client.js
+++ b/src/services/client.js
@@ -1,7 +1,8 @@
 
 export default function (...whitelist) {
+  whitelist = typeof whitelist === 'string' ? [whitelist] : whitelist;
+  
   return hook => {
-    whitelist = typeof whitelist === 'string' ? [whitelist] : whitelist;
     const params = hook.params;
 
     if (params && params.query && params.query.$client && typeof params.query.$client === 'object') {
@@ -13,6 +14,7 @@ export default function (...whitelist) {
         }
       });
 
+      params.query = JSON.parse(JSON.stringify(params.query));
       delete params.query.$client;
     }
 


### PR DESCRIPTION
**Note: Don't comment before looking at 'semistandard fix' which is more than what the desc says.** I hadn't had a coffee yet.

- The pgm may use a "const" { query: { $client: {...}}} as the hook.params in several method calls.
- The client hook will modify this "const" object and it will not function as expected in subsequent method calls.
- This subtle effect may be time consuming to find.