### PR TITLE
Update populate hook to call toJSON if implemented

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -110,6 +110,11 @@ function populateItem (options, hook, item, includeSchema, depth) {
         item._elapsed = elapsed;
       }
 
+      // #144 - Fixes issue with custom `toJSON` implementations (most ORMs)
+      if (typeof item.toJSON === 'function') {
+        item = item.toJSON();
+      }
+
       children.forEach(({ nameAs, items }) => {
         setByDot(item, nameAs, items);
       });

--- a/test/services/populate-relations.test.js
+++ b/test/services/populate-relations.test.js
@@ -243,6 +243,20 @@ const { populate } = require('../../src/services/index');
           );
         });
     });
+
+    it('for results with toJSON implemented', () => {
+      const hook = clone(hookAfter);
+      hook.app = app; // app is a func and wouldn't be cloned
+      hook.result = Object.assign({}, hook.result, {
+        toJSON: function () {
+          return { iam: 'a simple object' };
+        }
+      });
+      return populate({ schema, checkPermissions: () => true, profile: 'test' })(hook)
+        .then(hook1 => {
+          assert.ok(hook1.result.hasOwnProperty('iam'));
+        });
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #144 

I wholeheartedly believe this is the best solution. Please read my comments on the linked issue. I tested this with arrays of data (`GET /foo`) as well as with single items (`GET /foo/1`).