### PR TITLE
Add async schema validation support

### DIFF
--- a/src/services/validate-schema.js
+++ b/src/services/validate-schema.js
@@ -30,11 +30,13 @@ export default function (schema, ajvOrAjv, options = { allErrors: true }) {
         // Handler for synchronous validation
         .then((isValid) => {
           if (!isValid) {
-            // eslint-disable-next-line prefer-promise-reject-errors
-            return Promise.reject({errors: validate.errors});
+            return Promise.reject(
+              new ajv.constructor.ValidationError(validate.errors));
           }
         })
         .catch((err) => {
+          if (!(err instanceof ajv.constructor.ValidationError)) throw err;
+
           invalid = true;
 
           err.errors.forEach(ajvError => {

--- a/test/services/validate-schema.test.js
+++ b/test/services/validate-schema.test.js
@@ -7,6 +7,8 @@ describe('services validateSchema', () => {
   let hookBefore;
   let hookBeforeArray;
   let schema;
+  let asyncSchema;
+  let ajvAsync;
 
   beforeEach(() => {
     hookBefore = {
@@ -25,48 +27,155 @@ describe('services validateSchema', () => {
         { first: 'Joe', last: 'Doe' }
       ]
     };
-    schema = {
-      'properties': {
-        'first': { 'type': 'string' },
-        'last': { 'type': 'string' }
-      },
-      'required': ['first', 'last']
-    };
   });
 
-  it('works with valid single item', () => {
-    validateSchema(schema, Ajv)(hookBefore);
-  });
+  describe('Sync validation', () => {
+    beforeEach(() => {
+      schema = {
+        'properties': {
+          'first': { 'type': 'string' },
+          'last': { 'type': 'string' }
+        },
+        'required': ['first', 'last']
+      };
+    });
 
-  it('works with array of valid items', () => {
-    validateSchema(schema, Ajv)(hookBeforeArray);
-  });
+    it('works with valid single item', () => {
+      validateSchema(schema, Ajv)(hookBefore);
+    });
 
-  it('fails with in valid single item', () => {
-    hookBefore.data = { first: 1 };
+    it('works with array of valid items', () => {
+      validateSchema(schema, Ajv)(hookBeforeArray);
+    });
 
-    validateSchema(schema, Ajv)(hookBefore)
-        .catch((err) => {
-          assert.fail(true, false, 'test succeeds unexpectedly');
-          assert.deepEqual(err.errors, [
-            '\'first\' should be string',
-            'should have required property \'last\''
-          ]);
-        });
-  });
+    it('fails with in valid single item', () => {
+      hookBefore.data = { first: 1 };
 
-  it('fails with array of invalid items', () => {
-    hookBeforeArray.data[0] = { first: 1 };
-    delete hookBeforeArray.data[2].last;
-
-    validateSchema(schema, Ajv)(hookBefore)
-      .catch((err) => {
+      try {
+        validateSchema(schema, Ajv)(hookBefore);
         assert.fail(true, false, 'test succeeds unexpectedly');
+      } catch (err) {
+        assert.deepEqual(err.errors, [
+          '\'first\' should be string',
+          'should have required property \'last\''
+        ]);
+      }
+    });
+
+    it('fails with array of invalid items', () => {
+      hookBeforeArray.data[0] = { first: 1 };
+      delete hookBeforeArray.data[2].last;
+
+      try {
+        validateSchema(schema, Ajv)(hookBeforeArray);
+        assert.fail(true, false, 'test succeeds unexpectedly');
+      } catch (err) {
         assert.deepEqual(err.errors, [
           "'in row 1 of 3, first' should be string",
           "in row 1 of 3, should have required property 'last'",
           "in row 3 of 3, should have required property 'last'"
         ]);
+      }
+    });
+  });
+
+  describe('Async validation', () => {
+    before(() => {
+      ajvAsync = new Ajv({ allErrors: true });
+
+      ajvAsync.addKeyword('equalsDoe', {
+        async: true,
+        schema: false,
+        validate: (item) => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            item === 'Doe'
+              ? resolve(true)
+              : reject(new Ajv.ValidationError([{message: 'should be Doe'}]));
+          }, 50);
+        })
       });
+
+      ajvAsync.addFormat('3or4chars', {
+        async: true,
+        validate: (item) => new Promise((resolve, reject) => {
+          setTimeout(() => {
+            (item.length === 3 || item.length === 4)
+            ? resolve(true)
+            : resolve(false);
+          }, 50);
+        })
+      });
+    });
+
+    beforeEach(() => {
+      asyncSchema = {
+        '$async': true,
+        'properties': {
+          'first': {
+            'type': 'string',
+            'format': '3or4chars'
+          },
+          'last': {
+            'type': 'string',
+            'equalsDoe': true
+          }
+        },
+        'required': ['first', 'last']
+      };
+    });
+
+    it('works with valid single item', (next) => {
+      validateSchema(asyncSchema, ajvAsync)(hookBefore)
+        .then(() => {
+          next();
+        })
+        .catch((err) => {
+          console.log(err);
+          assert.fail(true, false, 'test fails unexpectedly');
+        });
+    });
+
+    it('works with array of valid items', (next) => {
+      validateSchema(asyncSchema, ajvAsync)(hookBeforeArray)
+        .then(() => {
+          next();
+        })
+        .catch(() => {
+          assert.fail(true, false, 'test fails unexpectedly');
+        });
+    });
+
+    it('fails with in valid single item', (next) => {
+      hookBefore.data = { first: '1' };
+
+      validateSchema(asyncSchema, ajvAsync)(hookBefore)
+        .then(() => {
+          assert.fail(true, false, 'test succeeds unexpectedly');
+        })
+        .catch((err) => {
+          assert.deepEqual(err.errors, [
+            '\'first\' should match format "3or4chars"',
+            'should have required property \'last\''
+          ]);
+          next();
+        });
+    });
+
+    it('fails with array of invalid items', (next) => {
+      hookBeforeArray.data[0].last = 'not Doe';
+      delete hookBeforeArray.data[2].last;
+
+      validateSchema(asyncSchema, ajvAsync)(hookBeforeArray)
+        .then(() => {
+          assert.fail(true, false, 'test succeeds unexpectedly');
+        })
+        .catch((err) => {
+          assert.deepEqual(err.errors, [
+            'in row 3 of 3, should have required property \'last\'',
+            '\'in row 1 of 3, last\' should be Doe'
+          ]);
+          next();
+        });
+    });
   });
 });

--- a/test/services/validate-schema.test.js
+++ b/test/services/validate-schema.test.js
@@ -45,30 +45,28 @@ describe('services validateSchema', () => {
   it('fails with in valid single item', () => {
     hookBefore.data = { first: 1 };
 
-    try {
-      validateSchema(schema, Ajv)(hookBefore);
-      assert.fail(true, false, 'test succeeds unexpectedly');
-    } catch (err) {
-      assert.deepEqual(err.errors, [
-        '\'first\' should be string',
-        'should have required property \'last\''
-      ]);
-    }
+    validateSchema(schema, Ajv)(hookBefore)
+        .catch((err) => {
+          assert.fail(true, false, 'test succeeds unexpectedly');
+          assert.deepEqual(err.errors, [
+            '\'first\' should be string',
+            'should have required property \'last\''
+          ]);
+        });
   });
 
   it('fails with array of invalid items', () => {
     hookBeforeArray.data[0] = { first: 1 };
     delete hookBeforeArray.data[2].last;
 
-    try {
-      validateSchema(schema, Ajv)(hookBeforeArray);
-      assert.fail(true, false, 'test succeeds unexpectedly');
-    } catch (err) {
-      assert.deepEqual(err.errors, [
-        "'in row 1 of 3, first' should be string",
-        "in row 1 of 3, should have required property 'last'",
-        "in row 3 of 3, should have required property 'last'"
-      ]);
-    }
+    validateSchema(schema, Ajv)(hookBefore)
+      .catch((err) => {
+        assert.fail(true, false, 'test succeeds unexpectedly');
+        assert.deepEqual(err.errors, [
+          "'in row 1 of 3, first' should be string",
+          "in row 1 of 3, should have required property 'last'",
+          "in row 3 of 3, should have required property 'last'"
+        ]);
+      });
   });
 });


### PR DESCRIPTION
### Summary

This PR aims to add support of asynchronous schema validation. Example of async schema:
```
var Ajv = require('ajv');
var ajv = Ajv({allErrors: true});

var request = require("request");

ajv.addFormat('twitter', {
    async: true,
    validate: (userName) => new Promise((resolve, reject) => {
        request.get('https://twitter.com/' + userName, (err, res) => {
            if (err) reject(err);
            else resolve(res.statusCode == 200)
        });
    })
});

var schema = {
    "$async": true,
    "properties": {
        "twitter_username": {
            "type": "string",
            "format": "twitter"
        }
    }
};
```
Example from https://runkit.com/esp/ajv-asynchronous-validation

### Other Information

I guess _potentially_ it could break something, because tests were written in synchronous try-catch way. But Feathers.js executes hooks in async manner, so this should be fine 🤔 