### PR TITLE
Soft delete will call service.get only once

### DIFF
--- a/src/services/soft-delete.js
+++ b/src/services/soft-delete.js
@@ -4,12 +4,8 @@ import checkContext from './check-context';
 
 const errors = feathersErrors.errors;
 
-export default function (field, options) {
+export default function (field) {
   const deleteField = field || 'deleted';
-  const {
-    // If true then call 'service.get' only once.
-    optimize = true
-  } = options || {};
 
   return function (hook) {
     const service = this;
@@ -28,13 +24,11 @@ export default function (field, options) {
       case 'get':
         return throwIfItemDeleted(hook.id)
           .then((data) => {
-            if (optimize) {
-              // We got data by calling the same 'service.get' with the
-              // $disableSoftDelete parameter which should not be used
-              // by service methods or other hooks,
-              // so there is no need to call 'service.get' twice.
-              hook.result = data;
-            }
+            // We got data by calling the same 'service.get' with the
+            // $disableSoftDelete parameter which should not be used
+            // by service methods or other hooks,
+            // so there is no need to call 'service.get' twice.
+            hook.result = data;
             return hook;
           });
       case 'create':

--- a/src/services/soft-delete.js
+++ b/src/services/soft-delete.js
@@ -17,6 +17,7 @@ export default function (field) {
       delete hook.params.query.$disableSoftDelete;
       return hook;
     }
+
     switch (hook.method) {
       case 'find':
         hook.params.query[deleteField] = { $ne: true };

--- a/src/services/validate-schema.js
+++ b/src/services/validate-schema.js
@@ -12,7 +12,7 @@ export default function (schema, ajvOrAjv, options = { allErrors: true }) {
   let ajv, Ajv;
   if (typeof ajvOrAjv.addKeyword !== 'function') {
     Ajv = ajvOrAjv;
-    ajv = new Ajv(options); 
+    ajv = new Ajv(options);
   } else {
     ajv = ajvOrAjv;
   }

--- a/test/services/soft-delete.test.js
+++ b/test/services/soft-delete.test.js
@@ -16,52 +16,47 @@ const storeInit = {
 };
 let store;
 
-function makeApp (options = {}) {
-  function services () {
-    const app = this;
-    app.configure(user);
-  }
+function services () {
+  const app = this;
+  app.configure(user);
+}
 
-  function user () {
-    const app = this;
-    store = clone(storeInit);
+function user () {
+  const app = this;
+  store = clone(storeInit);
 
-    class UsersService extends memory.Service {
-      constructor (...args) {
-        super(...args);
-        this.get_call_count = 0;
-      }
-      get (...args) {
-        this.get_call_count += 1;
-        return super.get(...args);
-      }
+  class UsersService extends memory.Service {
+    constructor (...args) {
+      super(...args);
+      this.get_call_count = 0;
     }
-
-    app.use('/users', new UsersService({store, startId}));
-
-    app.service('users').before({
-      all: [
-        hooks.softDelete(...(options.softDelete || []))
-          // hook => console.log('id=', hook.id, 'data=', hook.data, 'query=', hook.params.query),
-      ]
-    });
+    get (...args) {
+      this.get_call_count += 1;
+      return super.get(...args);
+    }
   }
 
-  return feathers()
-      .configure(feathersHooks())
-      .configure(services);
+  app.use('/users', new UsersService({store, startId}));
+
+  app.service('users').before({
+    all: [
+      hooks.softDelete()
+      // hook => console.log('id=', hook.id, 'data=', hook.data, 'query=', hook.params.query),
+    ]
+  });
 }
 
 describe('services softDelete', () => {
   let app;
   let user;
 
-  function prepareEnv (options) {
-    app = makeApp(options);
-    user = app.service('users');
-  }
+  beforeEach(() => {
+    app = feathers()
+      .configure(feathersHooks())
+      .configure(services);
 
-  beforeEach(() => prepareEnv());
+    user = app.service('users');
+  });
 
   describe('find', () => {
     it('find - does not return deleted items', done => {
@@ -74,16 +69,6 @@ describe('services softDelete', () => {
   });
 
   describe('get', () => {
-    it('returns an undeleted item calling "get" twice (old style)', done => {
-      prepareEnv({'softDelete': ['deleted', {optimize: false}]});
-      user.get(0)
-        .then(data => {
-          assert.deepEqual(data, storeInit['0']);
-          assert.equal(user.get_call_count, 2);
-          done();
-        });
-    });
-
     it('returns an undeleted item', done => {
       user.get(0)
         .then(data => {
@@ -111,6 +96,7 @@ describe('services softDelete', () => {
           done();
         })
         .then(data => {
+          assert.equal(user.get_call_count, 1);
           assert.fail(true, false);
           done();
         });
@@ -122,6 +108,7 @@ describe('services softDelete', () => {
           done();
         })
         .then(data => {
+          assert.equal(user.get_call_count, 0);
           assert.fail(true, false);
           done();
         });

--- a/test/services/soft-delete.test.js
+++ b/test/services/soft-delete.test.js
@@ -81,10 +81,10 @@ describe('services softDelete', () => {
     it('throws on deleted item', done => {
       user.get(2)
         .catch(() => {
+          assert.equal(user.get_call_count, 1);
           done();
         })
         .then(data => {
-          assert.equal(user.get_call_count, 1);
           assert.fail(true, false);
           done();
         });
@@ -93,10 +93,10 @@ describe('services softDelete', () => {
     it('throws on missing item', done => {
       user.get(99)
         .catch(() => {
+          assert.equal(user.get_call_count, 1);
           done();
         })
         .then(data => {
-          assert.equal(user.get_call_count, 1);
           assert.fail(true, false);
           done();
         });
@@ -105,10 +105,10 @@ describe('services softDelete', () => {
     it('throws on null id', done => {
       user.get()
         .catch(() => {
+          assert.equal(user.get_call_count, 1);
           done();
         })
         .then(data => {
-          assert.equal(user.get_call_count, 0);
           assert.fail(true, false);
           done();
         });


### PR DESCRIPTION
If you have a users service covered with softDelete hook, then there will be 2 users.get calls for every request to it and to eny other service, that requires a populated user, e.g. services that are covered with restrictToRoles.

Since users.get most likely is fetching data from the database it is expensive, because database ops usually are the most expensive operations in request handling code.

It have a significant impact on performance in high load projects.

Second call appears when softDelete hook is calling service.get while already processing service.get request, it is needed to check whether the resource is deleted or not. But after this check we have a complete result already, this result was processed by all succeeding hooks, so we do not need to call service.get second time.

The patch is eliminating unnecessary call while keeping an ability to work in the old way.

The only problem here as i can see is that after hooks will be called twice, it is not guaranteed that they correctly process the same result twice, so it would be great to find an option to return the result skipping other hooks, otherwise it is better to set optimize=false by default.

Tests patch is not the best of possible i'm sure, it would be great to see proposals of how to make it better.

Issue: #161.