### PR TITLE
Fixed populate to return [] or null if no joined records found. Issue…

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -191,6 +191,10 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
     .then(result => {
       result = result.data || result;
 
+      if (result.length === 0) {
+        return childSchema.asArray ? [] : null;
+      }
+
       if (result.length === 1 && !childSchema.asArray) {
         result = result[0];
       }

--- a/test/services/populate-1deep-1child.test.js
+++ b/test/services/populate-1deep-1child.test.js
@@ -140,6 +140,57 @@ const assert = chai.assert;
           });
       });
 
+      it('Stores null when no joined records and !asArray', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
+
+        hook.result.postId = '999';
+
+        const schema = {
+          include: makeInclude(type, {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id'
+          })
+        };
+
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+
+            expected.postId = '999';
+            expected.posts = null;
+
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
+
+      it('Stores [] when no joined records and asArray', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
+
+        hook.result.postId = '999';
+
+        const schema = {
+          include: makeInclude(type, {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            asArray: true
+          })
+        };
+
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+
+            expected.postId = '999';
+            expected.posts = [];
+
+            assert.deepEqual(hook1.result, expected);
+          });
+      });
+
       it('query overridden by childField', () => {
         const hook = clone(hookAfter);
         hook.app = app; // app is a func and wouldn't be cloned


### PR DESCRIPTION
Resolves https://github.com/feathersjs/feathers-hooks-common/issues/135 and will be published as v3.2.1.

If `parentItem[parentField] !== undefined` and no records are found for the join, `parentItem[nameAs]` will be `asArray ? [] : null`.