### PR TITLE
Added provider to populate schema. Issue #134

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -142,6 +142,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         query: { $limit: 5, $select: ['title', 'content', 'postId'], $sort: { createdAt: -1 } },
         select: (hook, parent, depth) => ({ something: { $exists: false }}),
         paginate: false,
+        provider: hook.provider,
         include: [ ... ] }
   @returns { nameAs: string, items: array }
   */
@@ -184,8 +185,13 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
       const paginateOption = childSchema.paginate;
       if (paginateOption === true) { paginate = null; }
       if (typeof paginateOption === 'number') { paginate = { paginate: { default: paginateOption } }; }
-
-      const params = Object.assign({}, hook.params, paginate, { query, _populate: 'skip' });
+  
+      const params = Object.assign({},
+        paginate,
+        { query, _populate: 'skip' },
+        { provider: ('provider' in childSchema) ? childSchema.provider : hook.params.provider }
+      );
+      
       return serviceHandle.find(params);
     })
     .then(result => {

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -185,13 +185,14 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
       const paginateOption = childSchema.paginate;
       if (paginateOption === true) { paginate = null; }
       if (typeof paginateOption === 'number') { paginate = { paginate: { default: paginateOption } }; }
-  
+
       const params = Object.assign({},
+        hook.params,
         paginate,
         { query, _populate: 'skip' },
-        { provider: ('provider' in childSchema) ? childSchema.provider : hook.params.provider }
+        ('provider' in childSchema) ? { provider: childSchema.provider } : {}
       );
-      
+
       return serviceHandle.find(params);
     })
     .then(result => {

--- a/test/services/populate-1deep-1child.test.js
+++ b/test/services/populate-1deep-1child.test.js
@@ -2,7 +2,7 @@
 const chai = require('chai');
 const configApp = require('../helpers/config-app');
 const getInitDb = require('../helpers/get-init-db');
-const { client, populate, setByDot } = require('../../src/services/index');
+const { populate, setByDot } = require('../../src/services/index');
 
 const assert = chai.assert;
 let provider;

--- a/test/services/populate-basics.test.js
+++ b/test/services/populate-basics.test.js
@@ -56,7 +56,7 @@ describe('services populate - finds items in hook', () => {
   });
 });
 
-describe('populate - throws on bad params', () => { // run to increase code climate score
+describe('services populate - throws on bad params', () => { // run to increase code climate score
   let hookAfter;
 
   beforeEach(() => {


### PR DESCRIPTION
The schema can now be
```javascript
const schema = { include: [
  service: ...
  parentField: ...
  childField: ...
  provider: undefined, // new
]};
```
`hook.params.provider` for the `.find` call resulting from the join is here set to `undefined`, hence hooks will process the `.find` as being made by the server.

By default the provider is set to that of the call to the base record.