### PR TITLE
enable array syntax for `iff`, `iff-else` and `when`

### DIFF
--- a/src/common/iff.js
+++ b/src/common/iff.js
@@ -1,13 +1,12 @@
 
 export default function (_iffElse) {
-  return function (predicate, ...rest) {
-    const trueHooks = [].concat(rest);
+  return function (predicate, ...trueHooks) {
     const that = this;
 
-    function iffWithoutElse (hook) {
-      return _iffElse(predicate, trueHooks, null).call(that, hook);
+    function iffWithoutElse(hook) {
+      return _iffElse(predicate, [].concat(...trueHooks), null).call(that, hook);
     }
-    iffWithoutElse.else = (...falseHooks) => _iffElse(predicate, trueHooks, falseHooks);
+    iffWithoutElse.else = (...falseHooks) => _iffElse(predicate, [].concat(...trueHooks), [].concat(...falseHooks));
 
     return iffWithoutElse;
   };

--- a/test/services/iff-else.test.js
+++ b/test/services/iff-else.test.js
@@ -330,10 +330,28 @@ describe('services iff - runs .else()', () => {
       hookFcnSync,
     )
       .else(
+      hookFcnSync,
+      hookFcnSync,
+      hookFcnSync
+      )(hook)
+      .then(hook => {
+        assert.equal(hookFcnSyncCalls, 3);
+        assert.equal(hookFcnAsyncCalls, 0);
+        assert.equal(hookFcnCbCalls, 0);
+
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('using if(false).else(...) with the array syntax', () => {
+    return hooks.iff(false,
+      [hookFcnSync],
+    )
+      .else([
         hookFcnSync,
         hookFcnSync,
         hookFcnSync
-      )(hook)
+      ])(hook)
       .then(hook => {
         assert.equal(hookFcnSyncCalls, 3);
         assert.equal(hookFcnAsyncCalls, 0);
@@ -390,6 +408,21 @@ describe('services iff - runs iff(true, iff(true, ...)', () => {
       hooks.iff(true, hookFcnCb),
       hookFcnAsync
     )(hook)
+      .then(hook => {
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 1);
+
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('runs iff(true, iff(true, hookFcnCb)) with the array syntax', () => {
+    return hooks.iff(true, [
+      hookFcnSync,
+      hooks.iff(true, [hookFcnCb]),
+      hookFcnAsync
+    ])(hook)
       .then(hook => {
         assert.equal(hookFcnSyncCalls, 1);
         assert.equal(hookFcnAsyncCalls, 1);
@@ -456,9 +489,9 @@ describe('services iff - runs iff(false).else(iff(...).else(...))', () => {
       hookFcnCb
     )
       .else(
-        hookFcnSync,
-        hooks.iff(true, hookFcnAsync),
-        hookFcnSync
+      hookFcnSync,
+      hooks.iff(true, hookFcnAsync),
+      hookFcnSync
       )(hook)
       .then(hook => {
         assert.equal(hookFcnSyncCalls, 2);
@@ -474,10 +507,28 @@ describe('services iff - runs iff(false).else(iff(...).else(...))', () => {
       hookFcnCb
     )
       .else(
-        hookFcnSync,
-        hooks.iff(false, hookFcnSync).else(hookFcnAsync),
-        hookFcnSync
+      hookFcnSync,
+      hooks.iff(false, hookFcnSync).else(hookFcnAsync),
+      hookFcnSync
       )(hook)
+      .then(hook => {
+        assert.equal(hookFcnSyncCalls, 2);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 0);
+
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('runs iff(false).else(iff(false).else(...)) with the array syntax', () => {
+    return hooks.iff(false,
+      [hookFcnCb]
+    )
+      .else([
+        hookFcnSync,
+        hooks.iff(false, [hookFcnSync]).else([hookFcnAsync]),
+        hookFcnSync
+      ])(hook)
       .then(hook => {
         assert.equal(hookFcnSyncCalls, 2);
         assert.equal(hookFcnAsyncCalls, 1);
@@ -520,11 +571,30 @@ describe('services iff - multiple iff() sequentially', () => {
       hookFcnCb
     )
       .else(
-        hookFcnSync,
-        hooks.iff(true, hookFcnAsync),
-        hooks.iff(false, hookFcnSync).else(hookFcnCb),
-        hookFcnSync
+      hookFcnSync,
+      hooks.iff(true, hookFcnAsync),
+      hooks.iff(false, hookFcnSync).else(hookFcnCb),
+      hookFcnSync
       )(hook)
+      .then(hook => {
+        assert.equal(hookFcnSyncCalls, 2);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 1);
+
+        assert.deepEqual(hook, hookAfter);
+      });
+  });
+
+  it('runs in iff(false).else(...) with the array syntax', () => {
+    return hooks.iff(false,
+      [hookFcnCb]
+    )
+      .else([
+        hookFcnSync,
+        hooks.iff(true, [hookFcnAsync]),
+        hooks.iff(false, [hookFcnSync]).else([hookFcnCb]),
+        hookFcnSync
+      ])(hook)
       .then(hook => {
         assert.equal(hookFcnSyncCalls, 2);
         assert.equal(hookFcnAsyncCalls, 1);

--- a/test/services/iff.test.js
+++ b/test/services/iff.test.js
@@ -398,6 +398,19 @@ describe('services iff - runs multiple hooks', () => {
         done();
       });
   });
+
+  it('runs successfully with the array syntax', (done) => {
+    hooks.iff(true, [hookFcnSync, hookFcnAsync, hookFcnCb])(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+
+        done();
+      });
+  });
 });
 
 // Helpers

--- a/test/services/when.test.js
+++ b/test/services/when.test.js
@@ -398,10 +398,23 @@ describe('services when - runs multiple hooks', () => {
         done();
       });
   });
+
+  it('runs successfully with the array syntax', (done) => {
+    hooks.when(true, [hookFcnSync, hookFcnAsync, hookFcnCb])(hook)
+      .then(hook => {
+        assert.deepEqual(hook, hookAfter);
+        assert.equal(hookFcnSyncCalls, 1);
+        assert.equal(hookFcnAsyncCalls, 1);
+        assert.equal(hookFcnCbCalls, 1);
+        assert.deepEqual(hook, hookAfter);
+
+        done();
+      });
+  });
 });
 
 // Helpers
 
-function clone (obj) {
+function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }


### PR DESCRIPTION
`iffElse` accepts arrays as the second and the third parameters, but currently `iff`, `when` and `iff-else` don't. This PR slightly changed the `iff.js` a little bit to enable the similiar array syntax for `iff`, `when` and `iff-else`.

Usages shown in the tests:

```js
hooks.when(true, [hookFcnSync, hookFcnAsync, hookFcnCb])

hooks.iff(false,
      [hookFcnSync],
    )
      .else([
        hookFcnSync,
        hookFcnSync,
        hookFcnSync
      ])
```
I could update the docs if you guys think this PR is feasible. ;)