### PR TITLE
Fix params-from-client import statement

### DIFF
--- a/src/services/params-from-client.js
+++ b/src/services/params-from-client.js
@@ -1,4 +1,4 @@
 
-import { client } from './client';
+import client from './client';
 
 export default client;


### PR DESCRIPTION
### Summary

The current import statement in `params-from-client.js` references a named export `client` that does not exist:
```
import { client } from './client'
// client is undefined
```

As a result, `paramsFromClient` is `undefined` when trying to import it:

```
const { paramsFromClient } = require('feathers-hooks-common')
// results in paramsFromClient === undefined
```

The import statement should reference the default export instead, which is what I propose in this pull request.