### PR TITLE
Added useInnerPopulate option to populate

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -143,6 +143,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         select: (hook, parent, depth) => ({ something: { $exists: false }}),
         paginate: false,
         provider: hook.provider,
+        useInnerPopulate: false,
         include: [ ... ] }
   @returns { nameAs: string, items: array }
   */
@@ -189,7 +190,8 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
       const params = Object.assign({},
         hook.params,
         paginate,
-        { query, _populate: 'skip' },
+        { query },
+        childSchema.useInnerPopulate ? { _populate: 'skip' } : {},
         ('provider' in childSchema) ? { provider: childSchema.provider } : {}
       );
 


### PR DESCRIPTION
populate, when including records from a child service, ignores any populate hooks defined for that child service. The userInnerPopulate option will run those populate hooks.

This allows the populate for a base record to include child records containing their own **immediate** child records, with the populate for the base record knowing what those grandchildren populates are.

Resolves https://github.com/feathersjs/feathers-hooks-common/issues/186