### PR TITLE
add missing `feathers-hooks` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ajv": "^5.0.0",
     "debug": "^2.2.0",
     "feathers-errors": "^2.4.0",
+    "feathers-hooks": "^2.0.1",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
@@ -68,7 +69,6 @@
     "coveralls": "^2.11.14",
     "eslint-if-supported": "^1.0.1",
     "feathers": "^2.0.3",
-    "feathers-hooks": "^2.0.0",
     "feathers-memory": "^1.0.1",
     "feathers-tests-fake-app-users": "^1.0.0",
     "istanbul": "^1.1.0-alpha.1",


### PR DESCRIPTION
`feathers-hooks` is used here: https://github.com/feathersjs/feathers-hooks-common/blob/8c1ab2fa228a2e2e42c311f48c99488900064296/src/services/combine.js

this change fixes an error when using `feathers-hooks-common` in a standalone module without `feathers-hooks` as a dependency.