### PR TITLE
Changed tests for chai 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-polyfill": "^6.20.0",
     "babel-preset-es2015": "^6.16.0",
-    "chai": "^3.5.0",
+    "chai": "^4.0.0",
     "coveralls": "^2.11.14",
     "eslint-if-supported": "^1.0.1",
     "feathers": "^2.0.3",

--- a/test/filters/set-filtered-at.test.js
+++ b/test/filters/set-filtered-at.test.js
@@ -96,7 +96,7 @@ describe('filters setFilteredAt', () => {
 
       setTimeout(() => {
         filters.setFilteredAt()(data);
-        assert.isAbove(result.filteredAt, firstTime);
+        assert.isAbove(result.filteredAt.getTime(), firstTime.getTime());
         next();
       }, 50);
     });

--- a/test/services/set-created-at.test.js
+++ b/test/services/set-created-at.test.js
@@ -135,7 +135,7 @@ describe('services setCreatedAt', () => {
 
       setTimeout(() => {
         hooks.setCreatedAt()(hookBefore);
-        assert.isAbove(hookBefore.data.createdAt, firstTime);
+        assert.isAbove(hookBefore.data.createdAt.getTime(), firstTime.getTime());
         next();
       }, 50);
     });

--- a/test/services/set-now.test.js
+++ b/test/services/set-now.test.js
@@ -151,7 +151,7 @@ describe('services setNow', () => {
 
       setTimeout(() => {
         hooks.setNow('createdAt')(hookBefore);
-        assert.isAbove(hookBefore.data.createdAt, firstTime);
+        assert.isAbove(hookBefore.data.createdAt.getTime(), firstTime.getTime());
         next();
       }, 50);
     });

--- a/test/services/set-updated-at.test.js
+++ b/test/services/set-updated-at.test.js
@@ -8,7 +8,7 @@ var hookAfter;
 var hookFindPaginate;
 var hookFind;
 
-describe('services setCreatedAt', () => {
+describe('services setUpdatedAt', () => {
   describe('updates fields', () => {
     beforeEach(() => {
       hookBefore = { type: 'before', method: 'create', data: { first: 'John', last: 'Doe' } };
@@ -134,7 +134,7 @@ describe('services setCreatedAt', () => {
 
       setTimeout(() => {
         hooks.setUpdatedAt()(hookBefore);
-        assert.isAbove(hookBefore.data.updatedAt, firstTime);
+        assert.isAbove(hookBefore.data.updatedAt.getTime(), firstTime.getTime());
         next();
       }, 50);
     });


### PR DESCRIPTION
assert now does not compare time objects. A .getTime() is needed.