### PR TITLE
Updated stashBefore so it clones context.data rather than references it.

### DIFF
--- a/src/services/stash-before.js
+++ b/src/services/stash-before.js
@@ -30,7 +30,7 @@ export default function (prop) {
       .then(data => {
         delete params.query.$disableStashBefore;
 
-        context.params[beforeField] = data;
+        context.params[beforeField] = JSON.parse(JSON.stringify(data));
         return context;
       })
       .catch(() => context);


### PR DESCRIPTION
Now context.params.before does not mutate when data does. This was even worse when feathers-memory was used as context.params.before pointed to the DB record.