### PR TITLE
Added hook utility thenifyHook

### DIFF
--- a/src/services/index.js
+++ b/src/services/index.js
@@ -37,6 +37,7 @@ import setUpdatedAt from './set-updated-at';
 import sifter from './sifter';
 import softDelete from './soft-delete';
 import stashBefore from './stash-before';
+import thenifyHook from './thenify-hook';
 import traverse from './traverse';
 import validate from './validate';
 import validateSchema from './validate-schema';
@@ -84,6 +85,7 @@ export default Object.assign(
     sifter,
     softDelete,
     stashBefore,
+    thenifyHook,
     traverse,
     validate,
     validateSchema

--- a/src/services/thenify-hook.js
+++ b/src/services/thenify-hook.js
@@ -1,0 +1,26 @@
+
+module.exports = function thenifyHook (extraContent1) {
+  const extraContent = extraContent1; // cannot access extraContent1 below. why not?
+
+  return hook => result => {
+    const context = Object.assign({}, { type: 'after', params: {}, result }, extraContent);
+
+    if (typeof result === 'object' && result !== null && result.total && result.data) {
+      context.method = 'find'; // needed by feathers-hooks-common/src/service/get-items.js
+    }
+
+    return Promise.resolve()
+      .then(() => hook(context))
+      .then(newContext => {
+        if (newContext === undefined) { return; }
+
+        const result = newContext.result;
+
+        if (typeof result === 'object' && result !== null && result.total && result.data) { // find
+          return newContext.result;
+        }
+
+        return newContext.result.data || newContext.result;
+      });
+  };
+};

--- a/test/services/exposed.js
+++ b/test/services/exposed.js
@@ -41,6 +41,7 @@ const hookNames = [
   'sifter',
   'softDelete',
   'stashBefore',
+  'thenifyHook',
   'traverse',
   'validate',
   'validateSchema',

--- a/test/services/thenify-hook.test.js
+++ b/test/services/thenify-hook.test.js
@@ -1,0 +1,55 @@
+
+import { assert } from 'chai';
+import { thenifyHook } from '../../src/services';
+
+let app = { a: 'a' };
+let params = { p: 'p' };
+let service = { s: 's' };
+let thenify;
+let hook;
+
+const testHook = hook1 => {
+  hook = hook1;
+
+  hook1._called = 'called';
+  return hook1;
+};
+
+describe('services thenifyHook', () => {
+  beforeEach(() => {
+    thenify = thenifyHook({ app, params, service });
+  });
+
+  it('get expected hook & object result', () => {
+    const data = { name: 'john' };
+
+    return Promise.resolve(data)
+        .then(thenify(testHook))
+        .then(result => {
+          assert.deepEqual(result, data, 'test result');
+          assert.deepEqual(hook, {
+            app, params, service, _called: 'called', result: data, type: 'after'
+          }, 'test hook');
+        });
+  });
+
+  it('get expected array result', () => {
+    const data = [{ name: 'john' }];
+
+    return Promise.resolve(data)
+      .then(thenify(testHook))
+      .then(result => {
+        assert.deepEqual(result, data, 'test result');
+      });
+  });
+
+  it('get expected find result', () => {
+    const data = { total: 1, data: [{ name: 'john' }] };
+
+    return Promise.resolve(data)
+      .then(thenify(testHook))
+      .then(result => {
+        assert.deepEqual(result, data, 'test result');
+      });
+  });
+});


### PR DESCRIPTION
Running an after hook conditionally can increase the cognative load. Consider running a `populate` conditionally:
```javascript
// in one place
service.get(id,{ _includeTeams: true });
// and in a separate module
after: { get: iff(context => context.params._includeTeams, populate(...)}
```

`thenifyHook` allows after hooks to run in the `.then` chain of the service call. The above can now be written as:
```javascript
const thenify = thenifyHook({ app }); // props to add to the hook call's `context`
service.get(id).then(thenify(populate(...)));
```
The intent is clearer.

`thenifyHook` can be used with any after hook once you set up the hook's context correctly.