### PR TITLE
Made `populate` hook friendlier to `thenifyHook` util

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -46,7 +46,7 @@ export default function (options, ...rest) {
           throw new errors.BadRequest('Permissions param is not a function. (populate)');
         }
 
-        if (baseService && baseService !== hook.path) {
+        if (baseService && hook.path && baseService !== hook.path) {
           throw new errors.BadRequest(`Schema is for ${baseService} not ${hook.path}. (populate)`);
         }
 


### PR DESCRIPTION
- if `schema.service` specifies the base service name, populate will not
throw if context.path isn't there.

So you don't have to include `path` when using `thenifyHook`.