### PR TITLE
Add top level provider option to populate hook

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -24,7 +24,8 @@ export default function (options, ...rest) {
     const optionsDefault = {
       schema: {},
       checkPermissions: () => true,
-      profile: false
+      profile: false,
+      provider: hook.params.provider
     };
 
     if (hook.params._populate === 'skip') { // this service call made from another populate
@@ -208,7 +209,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         paginateObj,
         { query: queryObj },
         useInnerPopulate ? {} : { _populate: 'skip' },
-        ('provider' in childSchema) ? { provider: childSchema.provider } : {}
+        ('provider' in childSchema) ? { provider: childSchema.provider } : { provider: options.provider }
       );
 
       return serviceHandle.find(params);

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -24,8 +24,7 @@ export default function (options, ...rest) {
     const optionsDefault = {
       schema: {},
       checkPermissions: () => true,
-      profile: false,
-      provider: hook.params.provider
+      profile: false
     };
 
     if (hook.params._populate === 'skip') { // this service call made from another populate
@@ -42,6 +41,7 @@ export default function (options, ...rest) {
         const schema1 = typeof schema === 'function' ? schema(hook, options1) : schema;
         const permissions = schema1.permissions || null;
         const baseService = schema1.service;
+        const provider = schema1.provider || hook.params.provider;
 
         if (typeof checkPermissions !== 'function') {
           throw new errors.BadRequest('Permissions param is not a function. (populate)');
@@ -59,7 +59,17 @@ export default function (options, ...rest) {
           throw new errors.BadRequest('Schema does not resolve to an object. (populate)');
         }
 
-        const include = [].concat(schema1.include || []);
+        const include = []
+          .concat(schema1.include || [])
+          .map(schema => {
+            if ('provider' in schema) {
+              return schema;
+            } else {
+              schema.provider = provider;
+              return schema;
+            }
+          });
+
         return !include.length ? items : populateItemArray(options1, hook, items, include, 0);
       })
       .then(items => {
@@ -154,7 +164,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
   */
 
   const {
-    childField, paginate, parentField, permissions, query, select, service, useInnerPopulate
+    childField, paginate, parentField, permissions, query, select, service, useInnerPopulate, provider
   } = childSchema;
 
   if (!service) {
@@ -209,7 +219,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         paginateObj,
         { query: queryObj },
         useInnerPopulate ? {} : { _populate: 'skip' },
-        ('provider' in childSchema) ? { provider: childSchema.provider } : { provider: options.provider }
+        ('provider' in childSchema) ? { provider: childSchema.provider } : {}
       );
 
       return serviceHandle.find(params);
@@ -225,8 +235,19 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
         result = result[0];
       }
 
+      const include = []
+        .concat(childSchema.include || [])
+        .map(schema => {
+          if ('provider' in schema) {
+            return schema;
+          } else {
+            schema.provider = provider;
+            return schema;
+          }
+        });
+
       return (childSchema.include && result)
-        ? populateItemArray(options, hook, result, childSchema.include, depth) : result;
+        ? populateItemArray(options, hook, result, include, depth) : result;
     })
     .then(items => ({ nameAs, items }));
 }

--- a/test/services/populate-1deep-1child.test.js
+++ b/test/services/populate-1deep-1child.test.js
@@ -261,11 +261,12 @@ let provider;
           });
       });
 
-      it('Provider can be passed down from options', () => {
+      it('Provider can be passed down from top level', () => {
         const hook = clone(hookAfter);
         hook.app = app; // app is a func and wouldn't be cloned
 
         const schema = {
+          provider: 'global',
           include: makeInclude(type, {
             service: 'posts',
             parentField: 'postId',
@@ -274,11 +275,11 @@ let provider;
           })
         };
 
-        return populate({ schema, provider: 'rest' })(hook)
+        return populate({ schema })(hook)
           .then(hook1 => {
             const expected = recommendationPosts('posts');
             assert.deepEqual(hook1.result, expected);
-            assert.equal(provider, 'rest');
+            assert.equal(provider, 'global');
           });
       });
 
@@ -287,6 +288,7 @@ let provider;
         hook.app = app; // app is a func and wouldn't be cloned
 
         const schema = {
+          provider: 'global',
           include: makeInclude(type, {
             service: 'posts',
             parentField: 'postId',
@@ -296,7 +298,7 @@ let provider;
           })
         };
 
-        return populate({ schema, provider: 'rest' })(hook)
+        return populate({ schema })(hook)
           .then(hook1 => {
             const expected = recommendationPosts('posts');
             assert.deepEqual(hook1.result, expected);

--- a/test/services/populate-1deep-1child.test.js
+++ b/test/services/populate-1deep-1child.test.js
@@ -261,6 +261,49 @@ let provider;
           });
       });
 
+      it('Provider can be passed down from options', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
+
+        const schema = {
+          include: makeInclude(type, {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            query: { id: 'aaaaaa' },
+          })
+        };
+
+        return populate({ schema, provider: 'rest' })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+            assert.equal(provider, 'rest');
+          });
+      });
+
+      it('Global provider can be overwritten at schema level', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
+
+        const schema = {
+          include: makeInclude(type, {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            query: { id: 'aaaaaa' },
+            provider: 'socketio'
+          })
+        };
+
+        return populate({ schema, provider: 'rest' })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+            assert.equal(provider, 'socketio');
+          });
+      });
+
       it('childField overridden by select', () => {
         const hook = clone(hookAfter);
         hook.app = app; // app is a func and wouldn't be cloned


### PR DESCRIPTION
### Summary

This pull request extends the populate hook to allow for the specification of a global provider for the entire populate tree, rather than specifying them on a per child schema basis. The motivation here is that it's quite easy to miss a provider somewhere in your schema tree, particularly if it is large.

In cases of nested includes, the provider will be inherited from the parent schema. If not specified, the provider will default to the hook's provider.

Example: 

```javascript
const schema = {
  service: 'users',
  nameAs: 'user',
  parentField: 'userId',
  childField: 'id',
  // undefined / server provider will be used unless overriden by a child schema
  provider: undefined,
  include: {
    service: 'notifications',
    nameAs: 'notifications',
    parentField: '_id',
    childField: 'userId',
    // `notifications` service will be accessed with the `rest` provider
    provider: 'rest'
  }
};

populate({ schema })
```