### PR TITLE
Correct falsy provider handling

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -41,7 +41,7 @@ export default function (options, ...rest) {
         const schema1 = typeof schema === 'function' ? schema(hook, options1) : schema;
         const permissions = schema1.permissions || null;
         const baseService = schema1.service;
-        const provider = schema1.provider || hook.params.provider;
+        const provider = ('provider' in schema1) ? schema1.provider : hook.params.provider;
 
         if (typeof checkPermissions !== 'function') {
           throw new errors.BadRequest('Permissions param is not a function. (populate)');

--- a/test/services/populate-1deep-1child.test.js
+++ b/test/services/populate-1deep-1child.test.js
@@ -306,6 +306,30 @@ let provider;
           });
       });
 
+      it('Falsy providers override default provider', () => {
+        const hook = clone(hookAfter);
+        hook.app = app; // app is a func and wouldn't be cloned
+        hook.params.provider = 'rest'; // Set up default provider
+
+        const schema = {
+          provider: undefined,
+          include: makeInclude(type, {
+            service: 'posts',
+            parentField: 'postId',
+            childField: 'id',
+            query: { id: 'aaaaaa' },
+          })
+        };
+
+        return populate({ schema })(hook)
+          .then(hook1 => {
+            const expected = recommendationPosts('posts');
+            assert.deepEqual(hook1.result, expected);
+            assert.equal(provider, undefined);
+          });
+
+      });
+
       it('childField overridden by select', () => {
         const hook = clone(hookAfter);
         hook.app = app; // app is a func and wouldn't be cloned


### PR DESCRIPTION
### Summary

This pull request corrects the handling of falsy values for the provider option at the top level of the populate schema tree. The remainder of the tree checks for presence (`'provider' in schema`) whereas the top level checked for truthiness (`schema.provider || hook.params.provider`).

Derp.