### PR TITLE
Fix _include being overwritten with empty array

### DIFF
--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -103,7 +103,7 @@ function populateItem (options, hook, item, includeSchema, depth) {
   const elapsed = {};
   const startAtAllIncludes = process.hrtime();
   const include = [].concat(includeSchema || []);
-  item._include = [];
+  if(!Object.prototype.hasOwnProperty.call(item, '_include')) item._include = [];
 
   return Promise.all(
     include.map(childSchema => {

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -103,7 +103,7 @@ function populateItem (options, hook, item, includeSchema, depth) {
   const elapsed = {};
   const startAtAllIncludes = process.hrtime();
   const include = [].concat(includeSchema || []);
-  if(!Object.prototype.hasOwnProperty.call(item, '_include')) item._include = [];
+  if (!Object.prototype.hasOwnProperty.call(item, '_include')) item._include = [];
 
   return Promise.all(
     include.map(childSchema => {
@@ -183,7 +183,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
   }
 
   const nameAs = childSchema.nameAs || service;
-  parentItem._include.push(nameAs);
+  if (parentItem._include.indexOf(nameAs)) parentItem._include.push(nameAs);
 
   return Promise.resolve()
     .then(() => (select ? select(hook, parentItem, depth) : {}))

--- a/src/services/populate.js
+++ b/src/services/populate.js
@@ -183,7 +183,7 @@ function populateAddChild (options, hook, parentItem, childSchema, depth) {
   }
 
   const nameAs = childSchema.nameAs || service;
-  if (parentItem._include.indexOf(nameAs)) parentItem._include.push(nameAs);
+  if (parentItem._include.indexOf(nameAs) === -1) parentItem._include.push(nameAs);
 
   return Promise.resolve()
     .then(() => (select ? select(hook, parentItem, depth) : {}))


### PR DESCRIPTION
Fix _include being overwritten with empty array so multiple / external populate functions can add to the _include too

**Problem before fix:**
I was writing a custom populate hook function and I wanted to have it also add it to the _include array so all the code is neat and consistent, but when I do another populate hook from feather after that it will set the array to empty so it will be removed, this will check if there is already an _include array before creating an empty one.