### PR TITLE
Allow schema IDs in first parameter of validateSchema

### DIFF
--- a/src/services/validate-schema.js
+++ b/src/services/validate-schema.js
@@ -16,7 +16,7 @@ export default function (schema, ajvOrAjv, options = { allErrors: true }) {
   } else {
     ajv = ajvOrAjv;
   }
-  const validate = ajv.compile(schema); // for fastest execution
+  const validate = (typeof schema === 'string') ? ajv.getSchema(schema) : ajv.compile(schema); // for fastest execution
 
   return hook => {
     const items = getItems(hook);
@@ -25,7 +25,7 @@ export default function (schema, ajvOrAjv, options = { allErrors: true }) {
     let errorMessages = null;
     let invalid = false;
 
-    if (schema.$async) {
+    if (validate.schema.$async) {
       return Promise.all(itemsArray.map((item, index) => {
         return validate(item)
           .catch(err => {

--- a/test/services/validate-schema.test.js
+++ b/test/services/validate-schema.test.js
@@ -5,6 +5,14 @@ import Ajv from 'ajv';
 
 const ajv = new Ajv({ allErrors: true });
 ajv.addFormat('startWithJo', '^Jo');
+ajv.addSchema({
+  'id': 'syncSchema',
+  'properties': {
+    'first': { 'type': 'string', 'format': 'startWithJo' },
+    'last': { 'type': 'string' }
+  },
+  'required': ['first', 'last']
+});
 
 describe('services validateSchema', () => {
   let hookBefore;
@@ -83,6 +91,14 @@ describe('services validateSchema', () => {
 
     it('works with array of valid items when ajv instance is passed', () => {
       validateSchema(schemaForAjvInstance, ajv)(hookBeforeArrayForAjvInstance);
+    });
+
+    it('works with valid single item with existing schema in ajv instance', () => {
+      validateSchema('syncSchema', ajv)(hookBefore);
+    });
+
+    it('works with array of valid items with existing schema in ajv instance', () => {
+      validateSchema('syncSchema', ajv)(hookBeforeArrayForAjvInstance);
     });
 
     it('fails with in valid single item', () => {
@@ -172,6 +188,22 @@ describe('services validateSchema', () => {
           }, 50);
         })
       });
+
+      ajvAsync.addSchema({
+        'id': 'asyncSchema',
+        '$async': true,
+        'properties': {
+          'first': {
+            'type': 'string',
+            'format': '3or4chars'
+          },
+          'last': {
+            'type': 'string',
+            'equalsDoe': true
+          }
+        },
+        'required': ['first', 'last']
+      });
     });
 
     beforeEach(() => {
@@ -189,6 +221,17 @@ describe('services validateSchema', () => {
         },
         'required': ['first', 'last']
       };
+    });
+
+    it('works with string schema id', (next) => {
+      validateSchema('asyncSchema', ajvAsync)(hookBefore)
+        .then(() => {
+          next();
+        })
+        .catch((err) => {
+          console.log(err);
+          assert.fail(true, false, 'test fails unexpectedly');
+        });
     });
 
     it('works with valid single item', (next) => {


### PR DESCRIPTION
### Summary

- [X] Tell us about the problem your pull request is solving.

This is not so much a problem as it is a convenience.  Users can optionally provide a schema ID for a pre-loaded schema in an ajv instance, rather than having to pull in the schema itself from elsewhere to set up the hook.  This helps ensure readable code and promotes schema re-use.

- [ ] Are there any open issues that are related to this?   -    No
- [ ] Is this PR dependent on PRs in other repos?    -   No

### Other Information

No other information I can think of which is relevant; it's a pretty small change.  I'm, of course, totally willing to submit a relevant PR to feathers-docs if this is merged.