### PR TITLE
no need for populate in softDelete

### DIFF
--- a/src/services/soft-delete.js
+++ b/src/services/soft-delete.js
@@ -58,6 +58,7 @@ export default function (field) {
       const params = isGet ? hook.params : {
         query: {},
         provider: hook.params.provider,
+        _populate: 'skip',
         authenticated: hook.params.authenticated,
         user: hook.params.user
       };

--- a/test/services/soft-delete.test.js
+++ b/test/services/soft-delete.test.js
@@ -342,7 +342,7 @@ describe('services softDelete', () => {
       getCallParams = null;
 
       const params = { a: 1, b: 2, authenticated: 'a', user: 'b' };
-      const expected = { query: { $disableSoftDelete: true }, authenticated: 'a', user: 'b' };
+      const expected = { query: { $disableSoftDelete: true }, authenticated: 'a', user: 'b', _populate: 'skip' };
 
       user.patch(0, { x: 1 }, params)
         .then(data => {


### PR DESCRIPTION
### Summary
softDelete checks only if (data[deleteField]) so there is no need this query should be populated.